### PR TITLE
Add backend services with domain models and tests

### DIFF
--- a/backend/api/audit.js
+++ b/backend/api/audit.js
@@ -1,0 +1,46 @@
+const express = require('express');
+
+function createAuditRouter({ auditEngine, feedbackService }) {
+  const router = express.Router();
+
+  router.get('/', async (req, res, next) => {
+    try {
+      const audits = await auditEngine.listAudits();
+      res.json(audits);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post('/', async (req, res, next) => {
+    try {
+      const created = await auditEngine.planAudit(req.body);
+      res.status(201).json(created);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.put('/:id', async (req, res, next) => {
+    try {
+      const updated = await auditEngine.updateAudit(req.params.id, req.body);
+      res.json(updated);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post('/:id/feedback', async (req, res, next) => {
+    try {
+      const payload = { ...req.body, engagementId: req.params.id };
+      const feedback = await feedbackService.submitFeedback(payload);
+      res.status(201).json(feedback);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}
+
+module.exports = createAuditRouter;

--- a/backend/api/auth.js
+++ b/backend/api/auth.js
@@ -1,0 +1,29 @@
+const express = require('express');
+
+function createAuthRouter({ authService }) {
+  const router = express.Router();
+
+  router.post('/login', async (req, res, next) => {
+    try {
+      const token = await authService.login(req.body);
+      res.status(200).json(token);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post('/refresh', async (req, res, next) => {
+    try {
+      const { token } = req.body;
+      const refreshed = await authService.refresh(token);
+      res.status(200).json(refreshed);
+    } catch (error) {
+      error.status = 401;
+      next(error);
+    }
+  });
+
+  return router;
+}
+
+module.exports = createAuthRouter;

--- a/backend/api/report.js
+++ b/backend/api/report.js
@@ -1,0 +1,36 @@
+const express = require('express');
+
+function createReportRouter({ reportService, coreIntegration }) {
+  const router = express.Router();
+
+  router.get('/', async (req, res, next) => {
+    try {
+      const reports = await reportService.listReports();
+      res.json(reports);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post('/', async (req, res, next) => {
+    try {
+      const stored = await reportService.generateAndStoreReport();
+      res.status(201).json(stored);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/summary', async (req, res, next) => {
+    try {
+      const summary = await coreIntegration.generateRiskReport();
+      res.json(summary);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}
+
+module.exports = createReportRouter;

--- a/backend/api/risk.js
+++ b/backend/api/risk.js
@@ -1,0 +1,36 @@
+const express = require('express');
+
+function createRiskRouter({ riskEngine }) {
+  const router = express.Router();
+
+  router.get('/', async (req, res, next) => {
+    try {
+      const risks = await riskEngine.listRisks();
+      res.json(risks);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post('/', async (req, res, next) => {
+    try {
+      const created = await riskEngine.createRisk(req.body);
+      res.status(201).json(created);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.put('/:id', async (req, res, next) => {
+    try {
+      const updated = await riskEngine.updateRisk(req.params.id, req.body);
+      res.json(updated);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  return router;
+}
+
+module.exports = createRiskRouter;

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,0 +1,38 @@
+const express = require('express');
+const cors = require('cors');
+const swaggerUi = require('swagger-ui-express');
+const swaggerSpec = require('./openapi');
+const { buildContainer } = require('./container');
+const createAuthRouter = require('./api/auth');
+const createRiskRouter = require('./api/risk');
+const createAuditRouter = require('./api/audit');
+const createReportRouter = require('./api/report');
+
+function createApp(container = buildContainer()) {
+  const app = express();
+
+  app.use(cors());
+  app.use(express.json());
+
+  app.use('/auth', createAuthRouter({ authService: container.authService }));
+  app.use('/risks', createRiskRouter({ riskEngine: container.riskEngine }));
+  app.use(
+    '/audits',
+    createAuditRouter({ auditEngine: container.auditEngine, feedbackService: container.feedbackService })
+  );
+  app.use(
+    '/reports',
+    createReportRouter({ reportService: container.reportService, coreIntegration: container.coreIntegration })
+  );
+
+  app.use('/docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec));
+
+  app.use((err, req, res, next) => {
+    const status = err.status || 400;
+    res.status(status).json({ error: err.message || 'Unhandled error' });
+  });
+
+  return app;
+}
+
+module.exports = { createApp };

--- a/backend/config/cache.js
+++ b/backend/config/cache.js
@@ -1,0 +1,21 @@
+const IORedis = require('ioredis');
+
+let redis;
+
+function createRedis(overrides = {}) {
+  if (redis) {
+    return redis;
+  }
+
+  const {
+    host = process.env.REDIS_HOST || '127.0.0.1',
+    port = process.env.REDIS_PORT ? Number(process.env.REDIS_PORT) : 6379,
+    password = process.env.REDIS_PASSWORD,
+    lazyConnect = true
+  } = overrides;
+
+  redis = new IORedis({ host, port, password, lazyConnect });
+  return redis;
+}
+
+module.exports = { createRedis };

--- a/backend/config/db.js
+++ b/backend/config/db.js
@@ -1,0 +1,29 @@
+const { Pool } = require('pg');
+
+let pool;
+
+function createPool(overrides = {}) {
+  if (pool) {
+    return pool;
+  }
+
+  const {
+    connectionString = process.env.DATABASE_URL,
+    host = process.env.PGHOST || 'localhost',
+    port = process.env.PGPORT ? Number(process.env.PGPORT) : 5432,
+    database = process.env.PGDATABASE || 'openia',
+    user = process.env.PGUSER || 'postgres',
+    password = process.env.PGPASSWORD || 'postgres',
+    max = 10
+  } = overrides;
+
+  pool = new Pool(
+    connectionString
+      ? { connectionString, max }
+      : { host, port, database, user, password, max }
+  );
+
+  return pool;
+}
+
+module.exports = { createPool };

--- a/backend/container.js
+++ b/backend/container.js
@@ -1,0 +1,52 @@
+const { createPool } = require('./config/db');
+const { createRedis } = require('./config/cache');
+const RiskRepository = require('./repositories/RiskRepository');
+const AuditRepository = require('./repositories/AuditRepository');
+const ReportRepository = require('./repositories/ReportRepository');
+const RiskEngine = require('./services/RiskEngine');
+const AuditEngine = require('./services/AuditEngine');
+const FeedbackService = require('./services/Feedback');
+const CoreIntegration = require('./services/CoreIntegration');
+const COSOService = require('./services/COSO');
+const IIAService = require('./services/IIA');
+const ReportService = require('./services/ReportService');
+const AuthService = require('./services/AuthService');
+
+function buildContainer(overrides = {}) {
+  const pool = overrides.pool || createPool(overrides.dbConfig);
+  const cache = overrides.cache || createRedis(overrides.cacheConfig);
+
+  const riskRepository = overrides.riskRepository || new RiskRepository({ pool, cache });
+  const auditRepository = overrides.auditRepository || new AuditRepository({ pool, cache });
+  const reportRepository = overrides.reportRepository || new ReportRepository({ pool, cache });
+
+  const riskEngine = overrides.riskEngine || new RiskEngine({ riskRepository });
+  const auditEngine = overrides.auditEngine || new AuditEngine({ auditRepository });
+  const feedbackService = overrides.feedbackService || new FeedbackService({ auditRepository });
+
+  const coreIntegration =
+    overrides.coreIntegration || new CoreIntegration({ riskEngine, auditEngine, reportRepository });
+
+  const reportService = overrides.reportService || new ReportService({ reportRepository, coreIntegration });
+  const authService = overrides.authService || new AuthService();
+  const cosoService = overrides.cosoService || new COSOService();
+  const iiaService = overrides.iiaService || new IIAService();
+
+  return {
+    pool,
+    cache,
+    riskRepository,
+    auditRepository,
+    reportRepository,
+    riskEngine,
+    auditEngine,
+    feedbackService,
+    reportService,
+    coreIntegration,
+    authService,
+    cosoService,
+    iiaService
+  };
+}
+
+module.exports = { buildContainer };

--- a/backend/domain/auditEngagement.js
+++ b/backend/domain/auditEngagement.js
@@ -1,0 +1,16 @@
+const { z } = require('zod');
+const { FindingSchema } = require('./finding');
+
+const AuditEngagementSchema = z.object({
+  id: z.string().uuid().optional(),
+  name: z.string().min(1),
+  scope: z.string().min(1),
+  status: z.enum(['draft', 'planned', 'in_progress', 'completed']).default('draft'),
+  findings: z.array(FindingSchema).default([])
+});
+
+function createAuditEngagement(input) {
+  return AuditEngagementSchema.parse(input);
+}
+
+module.exports = { AuditEngagementSchema, createAuditEngagement };

--- a/backend/domain/control.js
+++ b/backend/domain/control.js
@@ -1,0 +1,14 @@
+const { z } = require('zod');
+
+const ControlSchema = z.object({
+  id: z.string().uuid().optional(),
+  name: z.string().min(1),
+  description: z.string().min(1),
+  owner: z.string().min(1)
+});
+
+function createControl(input) {
+  return ControlSchema.parse(input);
+}
+
+module.exports = { ControlSchema, createControl };

--- a/backend/domain/finding.js
+++ b/backend/domain/finding.js
@@ -1,0 +1,16 @@
+const { z } = require('zod');
+
+const FindingSchema = z.object({
+  id: z.string().uuid().optional(),
+  title: z.string().min(1),
+  description: z.string().min(1),
+  severity: z.enum(['low', 'medium', 'high']),
+  remediation: z.string().optional(),
+  status: z.enum(['open', 'in_progress', 'closed']).default('open')
+});
+
+function createFinding(input) {
+  return FindingSchema.parse(input);
+}
+
+module.exports = { FindingSchema, createFinding };

--- a/backend/domain/risk.js
+++ b/backend/domain/risk.js
@@ -1,0 +1,17 @@
+const { z } = require('zod');
+const { ControlSchema } = require('./control');
+
+const RiskSchema = z.object({
+  id: z.string().uuid().optional(),
+  title: z.string().min(1),
+  description: z.string().min(1),
+  category: z.string().min(1),
+  severity: z.enum(['low', 'medium', 'high']),
+  controls: z.array(ControlSchema).default([])
+});
+
+function createRisk(input) {
+  return RiskSchema.parse(input);
+}
+
+module.exports = { RiskSchema, createRisk };

--- a/backend/jest.config.js
+++ b/backend/jest.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
+  verbose: true
+};

--- a/backend/mq/eventBus.js
+++ b/backend/mq/eventBus.js
@@ -1,0 +1,21 @@
+const { EventEmitter } = require('events');
+
+class EventBus {
+  constructor() {
+    this.emitter = new EventEmitter();
+  }
+
+  publish(event, payload) {
+    // Simulate asynchronous behaviour as Kafka/RabbitMQ would do.
+    setImmediate(() => {
+      this.emitter.emit(event, payload);
+    });
+  }
+
+  subscribe(event, handler) {
+    this.emitter.on(event, handler);
+    return () => this.emitter.off(event, handler);
+  }
+}
+
+module.exports = new EventBus();

--- a/backend/openapi.js
+++ b/backend/openapi.js
@@ -1,0 +1,341 @@
+const riskSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string', format: 'uuid' },
+    title: { type: 'string' },
+    description: { type: 'string' },
+    category: { type: 'string' },
+    severity: { type: 'string', enum: ['low', 'medium', 'high'] },
+    controls: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', format: 'uuid' },
+          name: { type: 'string' },
+          description: { type: 'string' },
+          owner: { type: 'string' }
+        },
+        required: ['name', 'description', 'owner']
+      }
+    }
+  },
+  required: ['title', 'description', 'category', 'severity']
+};
+
+const auditSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string', format: 'uuid' },
+    name: { type: 'string' },
+    scope: { type: 'string' },
+    status: { type: 'string', enum: ['draft', 'planned', 'in_progress', 'completed'] },
+    findings: {
+      type: 'array',
+      items: {
+        type: 'object',
+        properties: {
+          id: { type: 'string', format: 'uuid' },
+          title: { type: 'string' },
+          description: { type: 'string' },
+          severity: { type: 'string', enum: ['low', 'medium', 'high'] },
+          remediation: { type: 'string' },
+          status: { type: 'string', enum: ['open', 'in_progress', 'closed'] }
+        },
+        required: ['title', 'description', 'severity']
+      }
+    }
+  },
+  required: ['name', 'scope']
+};
+
+const reportSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string', format: 'uuid' },
+    content: { type: 'string' },
+    created_at: { type: 'string', format: 'date-time' }
+  }
+};
+
+const swaggerDefinition = {
+  openapi: '3.0.0',
+  info: {
+    title: 'OpenIA GRC Platform',
+    version: '1.0.0'
+  },
+  paths: {
+    '/auth/login': {
+      post: {
+        summary: 'Authenticate a user',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  username: { type: 'string' },
+                  password: { type: 'string' }
+                },
+                required: ['username', 'password']
+              }
+            }
+          }
+        },
+        responses: {
+          200: {
+            description: 'JWT token',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: { token: { type: 'string' } }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    '/auth/refresh': {
+      post: {
+        summary: 'Refresh a token',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: { token: { type: 'string' } },
+                required: ['token']
+              }
+            }
+          }
+        },
+        responses: {
+          200: {
+            description: 'Refreshed token',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: { token: { type: 'string' } }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    '/risks': {
+      get: {
+        summary: 'List risks',
+        responses: {
+          200: {
+            description: 'List of risks',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'array',
+                  items: riskSchema
+                }
+              }
+            }
+          }
+        }
+      },
+      post: {
+        summary: 'Create a risk',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: riskSchema }
+          }
+        },
+        responses: {
+          201: {
+            description: 'Risk created',
+            content: {
+              'application/json': { schema: riskSchema }
+            }
+          }
+        }
+      }
+    },
+    '/risks/{id}': {
+      put: {
+        summary: 'Update a risk',
+        parameters: [
+          {
+            name: 'id',
+            in: 'path',
+            required: true,
+            schema: { type: 'string' }
+          }
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: { ...riskSchema, required: [] } }
+          }
+        },
+        responses: {
+          200: {
+            description: 'Risk updated',
+            content: {
+              'application/json': { schema: riskSchema }
+            }
+          }
+        }
+      }
+    },
+    '/audits': {
+      get: {
+        summary: 'List audits',
+        responses: {
+          200: {
+            description: 'List of audits',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'array',
+                  items: auditSchema
+                }
+              }
+            }
+          }
+        }
+      },
+      post: {
+        summary: 'Plan an audit',
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: auditSchema }
+          }
+        },
+        responses: {
+          201: {
+            description: 'Audit created',
+            content: {
+              'application/json': { schema: auditSchema }
+            }
+          }
+        }
+      }
+    },
+    '/audits/{id}': {
+      put: {
+        summary: 'Update an audit',
+        parameters: [
+          { name: 'id', in: 'path', required: true, schema: { type: 'string' } }
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': { schema: { ...auditSchema, required: [] } }
+          }
+        },
+        responses: {
+          200: {
+            description: 'Audit updated',
+            content: {
+              'application/json': { schema: auditSchema }
+            }
+          }
+        }
+      }
+    },
+    '/audits/{id}/feedback': {
+      post: {
+        summary: 'Submit audit feedback',
+        parameters: [
+          { name: 'id', in: 'path', required: true, schema: { type: 'string' } }
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  rating: { type: 'integer', minimum: 1, maximum: 5 },
+                  comment: { type: 'string' }
+                },
+                required: ['rating']
+              }
+            }
+          }
+        },
+        responses: {
+          201: {
+            description: 'Feedback captured',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    engagementId: { type: 'string' },
+                    rating: { type: 'integer' },
+                    comment: { type: 'string' }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    '/reports': {
+      get: {
+        summary: 'List reports',
+        responses: {
+          200: {
+            description: 'List of reports',
+            content: {
+              'application/json': {
+                schema: { type: 'array', items: reportSchema }
+              }
+            }
+          }
+        }
+      },
+      post: {
+        summary: 'Generate a summary report',
+        responses: {
+          201: {
+            description: 'Report generated',
+            content: {
+              'application/json': { schema: reportSchema }
+            }
+          }
+        }
+      }
+    },
+    '/reports/summary': {
+      get: {
+        summary: 'Get aggregated risk/audit summary',
+        responses: {
+          200: {
+            description: 'Summary snapshot',
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    totalRisks: { type: 'integer' },
+                    highSeverityRisks: { type: 'integer' },
+                    plannedAudits: { type: 'integer' }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+};
+
+module.exports = swaggerDefinition;

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "openia-backend",
+  "version": "1.0.0",
+  "description": "Governance, Risk and Compliance backend services",
+  "main": "server.js",
+  "type": "commonjs",
+  "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js",
+    "test": "jest --runInBand"
+  },
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "joi": "^17.10.1",
+    "pg": "^8.11.3",
+    "swagger-jsdoc": "^6.2.8",
+    "swagger-ui-express": "^4.7.2",
+    "zod": "^3.22.4",
+    "ioredis": "^5.3.2"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
+  }
+}

--- a/backend/repositories/AuditRepository.js
+++ b/backend/repositories/AuditRepository.js
@@ -1,0 +1,25 @@
+const BaseRepository = require('./BaseRepository');
+
+class AuditRepository extends BaseRepository {
+  constructor({ pool, cache }) {
+    super({ pool, cache, table: 'audits' });
+  }
+
+  async findPlannedAudits() {
+    const cacheKey = 'audits:planned';
+    if (this.cache) {
+      const cached = await this.cache.get(cacheKey);
+      if (cached) {
+        return JSON.parse(cached);
+      }
+    }
+
+    const { rows } = await this.pool.query('SELECT * FROM audits WHERE status = $1', ['planned']);
+    if (this.cache) {
+      await this.cache.set(cacheKey, JSON.stringify(rows), 'EX', 60);
+    }
+    return rows;
+  }
+}
+
+module.exports = AuditRepository;

--- a/backend/repositories/BaseRepository.js
+++ b/backend/repositories/BaseRepository.js
@@ -1,0 +1,69 @@
+class BaseRepository {
+  constructor({ pool, cache, table }) {
+    if (!pool) {
+      throw new Error('Pool is required');
+    }
+    this.pool = pool;
+    this.cache = cache;
+    this.table = table;
+  }
+
+  async findAll(cacheKey = `${this.table}:all`) {
+    if (this.cache) {
+      const cached = await this.cache.get(cacheKey);
+      if (cached) {
+        return JSON.parse(cached);
+      }
+    }
+
+    const { rows } = await this.pool.query(`SELECT * FROM ${this.table}`);
+    if (this.cache) {
+      await this.cache.set(cacheKey, JSON.stringify(rows), 'EX', 60);
+    }
+    return rows;
+  }
+
+  async findById(id) {
+    const cacheKey = `${this.table}:${id}`;
+    if (this.cache) {
+      const cached = await this.cache.get(cacheKey);
+      if (cached) {
+        return JSON.parse(cached);
+      }
+    }
+
+    const { rows } = await this.pool.query(`SELECT * FROM ${this.table} WHERE id = $1`, [id]);
+    const entity = rows[0] || null;
+    if (entity && this.cache) {
+      await this.cache.set(cacheKey, JSON.stringify(entity), 'EX', 60);
+    }
+    return entity;
+  }
+
+  async create(data) {
+    const fields = Object.keys(data);
+    const values = Object.values(data);
+    const placeholders = fields.map((_, idx) => `$${idx + 1}`).join(', ');
+    const sql = `INSERT INTO ${this.table} (${fields.join(', ')}) VALUES (${placeholders}) RETURNING *`;
+    const { rows } = await this.pool.query(sql, values);
+    if (this.cache) {
+      await this.cache.del(`${this.table}:all`);
+    }
+    return rows[0];
+  }
+
+  async update(id, data) {
+    const fields = Object.keys(data);
+    const values = Object.values(data);
+    const assignments = fields.map((field, idx) => `${field} = $${idx + 1}`).join(', ');
+    const sql = `UPDATE ${this.table} SET ${assignments} WHERE id = $${fields.length + 1} RETURNING *`;
+    const { rows } = await this.pool.query(sql, [...values, id]);
+    if (this.cache) {
+      await this.cache.del(`${this.table}:all`);
+      await this.cache.del(`${this.table}:${id}`);
+    }
+    return rows[0];
+  }
+}
+
+module.exports = BaseRepository;

--- a/backend/repositories/ReportRepository.js
+++ b/backend/repositories/ReportRepository.js
@@ -1,0 +1,9 @@
+const BaseRepository = require('./BaseRepository');
+
+class ReportRepository extends BaseRepository {
+  constructor({ pool, cache }) {
+    super({ pool, cache, table: 'reports' });
+  }
+}
+
+module.exports = ReportRepository;

--- a/backend/repositories/RiskRepository.js
+++ b/backend/repositories/RiskRepository.js
@@ -1,0 +1,25 @@
+const BaseRepository = require('./BaseRepository');
+
+class RiskRepository extends BaseRepository {
+  constructor({ pool, cache }) {
+    super({ pool, cache, table: 'risks' });
+  }
+
+  async findByCategory(category) {
+    const cacheKey = `risks:category:${category}`;
+    if (this.cache) {
+      const cached = await this.cache.get(cacheKey);
+      if (cached) {
+        return JSON.parse(cached);
+      }
+    }
+
+    const { rows } = await this.pool.query('SELECT * FROM risks WHERE category = $1', [category]);
+    if (this.cache) {
+      await this.cache.set(cacheKey, JSON.stringify(rows), 'EX', 60);
+    }
+    return rows;
+  }
+}
+
+module.exports = RiskRepository;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,8 @@
+const { createApp } = require('./app');
+
+const app = createApp();
+const port = process.env.PORT || 3000;
+
+app.listen(port, () => {
+  console.log(`OpenIA backend listening on port ${port}`);
+});

--- a/backend/services/AuditEngine.js
+++ b/backend/services/AuditEngine.js
@@ -1,0 +1,28 @@
+const { createAuditEngagement, AuditEngagementSchema } = require('../domain/auditEngagement');
+const eventBus = require('../mq/eventBus');
+
+class AuditEngine {
+  constructor({ auditRepository }) {
+    this.auditRepository = auditRepository;
+  }
+
+  async listAudits() {
+    return this.auditRepository.findAll();
+  }
+
+  async planAudit(input) {
+    const engagement = createAuditEngagement({ ...input, status: 'planned' });
+    const stored = await this.auditRepository.create(engagement);
+    eventBus.publish('audit_planned', stored);
+    return stored;
+  }
+
+  async updateAudit(id, input) {
+    const engagement = AuditEngagementSchema.partial().parse(input);
+    const updated = await this.auditRepository.update(id, engagement);
+    eventBus.publish('audit_updated', updated);
+    return updated;
+  }
+}
+
+module.exports = AuditEngine;

--- a/backend/services/AuthService.js
+++ b/backend/services/AuthService.js
@@ -1,0 +1,32 @@
+const Joi = require('joi');
+
+const loginSchema = Joi.object({
+  username: Joi.string().required(),
+  password: Joi.string().required()
+});
+
+class AuthService {
+  constructor() {
+    this.tokens = new Map();
+  }
+
+  async login(credentials) {
+    const { username } = await loginSchema.validateAsync(credentials);
+    const token = `token-${Buffer.from(username).toString('base64')}`;
+    this.tokens.set(token, { username, issuedAt: Date.now() });
+    return { token };
+  }
+
+  async refresh(token) {
+    if (!this.tokens.has(token)) {
+      throw new Error('Invalid token');
+    }
+    const payload = this.tokens.get(token);
+    const newToken = `token-${Date.now()}`;
+    this.tokens.delete(token);
+    this.tokens.set(newToken, { ...payload, refreshedAt: Date.now() });
+    return { token: newToken };
+  }
+}
+
+module.exports = AuthService;

--- a/backend/services/COSO.js
+++ b/backend/services/COSO.js
@@ -1,0 +1,19 @@
+class COSOService {
+  constructor() {
+    this.principles = ['Control Environment', 'Risk Assessment', 'Control Activities', 'Information & Communication', 'Monitoring'];
+  }
+
+  evaluateRiskMaturity(risk) {
+    const score = this.principles.reduce((acc, principle) => {
+      const weight = principle.length % 5 + 1;
+      return acc + weight;
+    }, 0);
+    return {
+      riskId: risk.id,
+      maturityScore: score,
+      notes: 'Illustrative COSO assessment using static weighting.'
+    };
+  }
+}
+
+module.exports = COSOService;

--- a/backend/services/CoreIntegration.js
+++ b/backend/services/CoreIntegration.js
@@ -1,0 +1,31 @@
+class CoreIntegration {
+  constructor({ riskEngine, auditEngine, reportRepository }) {
+    this.riskEngine = riskEngine;
+    this.auditEngine = auditEngine;
+    this.reportRepository = reportRepository;
+  }
+
+  async generateRiskReport() {
+    const [risks, audits] = await Promise.all([
+      this.riskEngine.listRisks(),
+      this.auditEngine.listAudits()
+    ]);
+
+    const summary = {
+      totalRisks: risks.length,
+      highSeverityRisks: risks.filter((risk) => risk.severity === 'high').length,
+      plannedAudits: audits.filter((audit) => audit.status === 'planned').length
+    };
+
+    return summary;
+  }
+
+  async persistReport(content) {
+    return this.reportRepository.create({
+      content: JSON.stringify(content),
+      created_at: new Date().toISOString()
+    });
+  }
+}
+
+module.exports = CoreIntegration;

--- a/backend/services/Feedback.js
+++ b/backend/services/Feedback.js
@@ -1,0 +1,23 @@
+const Joi = require('joi');
+const eventBus = require('../mq/eventBus');
+
+const feedbackSchema = Joi.object({
+  engagementId: Joi.string().required(),
+  comment: Joi.string().allow('').default(''),
+  rating: Joi.number().integer().min(1).max(5).required()
+});
+
+class FeedbackService {
+  constructor({ auditRepository }) {
+    this.auditRepository = auditRepository;
+  }
+
+  async submitFeedback(input) {
+    const feedback = await feedbackSchema.validateAsync(input);
+    // In real implementation we'd persist; here we just emit event.
+    eventBus.publish('feedback_received', feedback);
+    return feedback;
+  }
+}
+
+module.exports = FeedbackService;

--- a/backend/services/IIA.js
+++ b/backend/services/IIA.js
@@ -1,0 +1,16 @@
+class IIAService {
+  constructor() {
+    this.standards = ['Independence', 'Objectivity', 'Proficiency', 'Quality Assurance'];
+  }
+
+  assessAuditQuality(audit) {
+    const metStandards = this.standards.filter(() => audit.status !== 'draft');
+    return {
+      auditId: audit.id,
+      standardsMet: metStandards,
+      qualityIndex: metStandards.length / this.standards.length
+    };
+  }
+}
+
+module.exports = IIAService;

--- a/backend/services/ReportService.js
+++ b/backend/services/ReportService.js
@@ -1,0 +1,17 @@
+class ReportService {
+  constructor({ reportRepository, coreIntegration }) {
+    this.reportRepository = reportRepository;
+    this.coreIntegration = coreIntegration;
+  }
+
+  async listReports() {
+    return this.reportRepository.findAll();
+  }
+
+  async generateAndStoreReport() {
+    const summary = await this.coreIntegration.generateRiskReport();
+    return this.coreIntegration.persistReport(summary);
+  }
+}
+
+module.exports = ReportService;

--- a/backend/services/RiskEngine.js
+++ b/backend/services/RiskEngine.js
@@ -1,0 +1,28 @@
+const { createRisk, RiskSchema } = require('../domain/risk');
+const eventBus = require('../mq/eventBus');
+
+class RiskEngine {
+  constructor({ riskRepository }) {
+    this.riskRepository = riskRepository;
+  }
+
+  async listRisks() {
+    return this.riskRepository.findAll();
+  }
+
+  async createRisk(input) {
+    const risk = createRisk(input);
+    const stored = await this.riskRepository.create(risk);
+    eventBus.publish('risk_created', stored);
+    return stored;
+  }
+
+  async updateRisk(id, input) {
+    const risk = RiskSchema.partial().parse(input);
+    const updated = await this.riskRepository.update(id, risk);
+    eventBus.publish('risk_updated', updated);
+    return updated;
+  }
+}
+
+module.exports = RiskEngine;

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -1,0 +1,67 @@
+const request = require('supertest');
+const { createApp } = require('../app');
+
+describe('API contract tests', () => {
+  let app;
+  let container;
+
+  beforeEach(() => {
+    container = {
+      authService: { login: jest.fn().mockResolvedValue({ token: 'abc' }), refresh: jest.fn() },
+      riskEngine: {
+        listRisks: jest.fn().mockResolvedValue([{ id: '1', title: 'Risk', description: 'Desc', category: 'IT', severity: 'high' }]),
+        createRisk: jest.fn().mockResolvedValue({ id: '2' }),
+        updateRisk: jest.fn().mockResolvedValue({ id: '2' })
+      },
+      auditEngine: {
+        listAudits: jest.fn().mockResolvedValue([{ id: '1', name: 'Audit', scope: 'SOX', status: 'planned' }]),
+        planAudit: jest.fn().mockResolvedValue({ id: '2', status: 'planned' }),
+        updateAudit: jest.fn().mockResolvedValue({ id: '2', status: 'in_progress' })
+      },
+      feedbackService: {
+        submitFeedback: jest.fn().mockResolvedValue({ engagementId: '1', rating: 5, comment: 'Great' })
+      },
+      reportService: {
+        listReports: jest.fn().mockResolvedValue([{ id: '1', content: '{}', created_at: new Date().toISOString() }]),
+        generateAndStoreReport: jest.fn().mockResolvedValue({ id: '2', content: '{}', created_at: new Date().toISOString() })
+      },
+      coreIntegration: {
+        generateRiskReport: jest.fn().mockResolvedValue({ totalRisks: 1, highSeverityRisks: 1, plannedAudits: 1 })
+      }
+    };
+
+    app = createApp(container);
+  });
+
+  test('POST /auth/login returns token', async () => {
+    const response = await request(app).post('/auth/login').send({ username: 'john', password: 'secret' });
+    expect(response.status).toBe(200);
+    expect(response.body.token).toBe('abc');
+    expect(container.authService.login).toHaveBeenCalledWith({ username: 'john', password: 'secret' });
+  });
+
+  test('GET /risks returns list of risks', async () => {
+    const response = await request(app).get('/risks');
+    expect(response.status).toBe(200);
+    expect(Array.isArray(response.body)).toBe(true);
+    expect(response.body[0].title).toBe('Risk');
+  });
+
+  test('POST /audits plans audit and returns 201', async () => {
+    const response = await request(app).post('/audits').send({ name: 'New Audit', scope: 'ISO' });
+    expect(response.status).toBe(201);
+    expect(container.auditEngine.planAudit).toHaveBeenCalled();
+  });
+
+  test('POST /audits/:id/feedback delegates to feedback service', async () => {
+    const response = await request(app).post('/audits/1/feedback').send({ rating: 5, comment: 'Great' });
+    expect(response.status).toBe(201);
+    expect(container.feedbackService.submitFeedback).toHaveBeenCalledWith({ engagementId: '1', rating: 5, comment: 'Great' });
+  });
+
+  test('GET /reports/summary returns aggregated metrics', async () => {
+    const response = await request(app).get('/reports/summary');
+    expect(response.status).toBe(200);
+    expect(response.body.totalRisks).toBe(1);
+  });
+});

--- a/backend/tests/auditEngine.test.js
+++ b/backend/tests/auditEngine.test.js
@@ -1,0 +1,31 @@
+const AuditEngine = require('../services/AuditEngine');
+const eventBus = require('../mq/eventBus');
+
+describe('AuditEngine', () => {
+  let repository;
+  let auditEngine;
+
+  beforeEach(() => {
+    repository = {
+      findAll: jest.fn().mockResolvedValue([]),
+      create: jest.fn().mockImplementation(async (audit) => ({ id: 'A1', ...audit })),
+      update: jest.fn().mockImplementation(async (id, audit) => ({ id, ...audit }))
+    };
+    auditEngine = new AuditEngine({ auditRepository: repository });
+    eventBus.emitter.removeAllListeners();
+  });
+
+  test('planAudit publishes audit_planned event', async () => {
+    const payload = { name: 'IT Audit', scope: 'Infrastructure' };
+
+    const eventPromise = new Promise((resolve) => {
+      eventBus.subscribe('audit_planned', resolve);
+    });
+
+    const created = await auditEngine.planAudit(payload);
+    expect(created.status).toBe('planned');
+    const event = await eventPromise;
+    expect(event.id).toBe('A1');
+    expect(repository.create).toHaveBeenCalled();
+  });
+});

--- a/backend/tests/riskEngine.test.js
+++ b/backend/tests/riskEngine.test.js
@@ -1,0 +1,48 @@
+const RiskEngine = require('../services/RiskEngine');
+const eventBus = require('../mq/eventBus');
+
+describe('RiskEngine', () => {
+  let repository;
+  let riskEngine;
+
+  beforeEach(() => {
+    repository = {
+      findAll: jest.fn(),
+      create: jest.fn().mockImplementation(async (risk) => ({ id: '123', ...risk })),
+      update: jest.fn().mockImplementation(async (id, risk) => ({ id, ...risk }))
+    };
+    riskEngine = new RiskEngine({ riskRepository: repository });
+    eventBus.emitter.removeAllListeners();
+  });
+
+  test('createRisk persists risk and emits risk_created', async () => {
+    const payload = {
+      title: 'Data breach',
+      description: 'Potential data leak',
+      category: 'Cyber',
+      severity: 'high',
+      controls: []
+    };
+
+    const eventPromise = new Promise((resolve) => {
+      eventBus.subscribe('risk_created', resolve);
+    });
+
+    const created = await riskEngine.createRisk(payload);
+    expect(created.id).toBe('123');
+    const event = await eventPromise;
+    expect(event.id).toBe('123');
+    expect(repository.create).toHaveBeenCalled();
+  });
+
+  test('updateRisk emits risk_updated message', async () => {
+    const eventPromise = new Promise((resolve) => {
+      eventBus.subscribe('risk_updated', resolve);
+    });
+
+    await riskEngine.updateRisk('123', { severity: 'medium' });
+    const event = await eventPromise;
+    expect(event.id).toBe('123');
+    expect(repository.update).toHaveBeenCalledWith('123', { severity: 'medium' });
+  });
+});


### PR DESCRIPTION
## Summary
- scaffold an Express-based backend with auth, risk, audit, and report APIs served under `/auth`, `/risks`, `/audits`, and `/reports`
- add domain validation models, PostgreSQL repositories with Redis caching hooks, and orchestration services including COSO/IIA helpers
- wire business engines to an event bus simulating Kafka/RabbitMQ and document endpoints with an OpenAPI spec while providing Jest test coverage for APIs and engines

## Testing
- `npm test` *(fails: jest not found because dependencies cannot be installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cdbb61f3f883288915e9ed979d4c28