### PR TITLE
Add infrastructure scaffolding and tooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,30 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+
+      - name: Bootstrap project
+        run: bash scripts/bootstrap.sh --ci
+
+      - name: Run tests
+        run: bash scripts/test.sh --ci

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+# Python cache
+__pycache__/
+*.py[cod]
+
+# Node modules
+node_modules/
+
+# Local environment files
+infrastructure/storage/config.yml
+
+# Docker artifacts
+*.log

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,107 @@
+version: "3.9"
+
+services:
+  backend:
+    build:
+      context: ./services/backend
+    command: ["bash", "-c", "echo 'Backend container ready. Attach to run the API.' && tail -f /dev/null"]
+    environment:
+      DATABASE_URL: postgres://openia:openia@db:5432/openia
+      REDIS_URL: redis://redis:6379/0
+      KAFKA_BROKERS: kafka:9092
+      STORAGE_CONFIG: /app/config/storage.yml
+    volumes:
+      - ./:/workspace:delegated
+    working_dir: /workspace
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      kafka:
+        condition: service_started
+    ports:
+      - "8000:8000"
+
+  worker:
+    build:
+      context: ./services/backend
+    command: ["bash", "-c", "echo 'Worker container idle. Override command to run background jobs.' && tail -f /dev/null"]
+    environment:
+      DATABASE_URL: postgres://openia:openia@db:5432/openia
+      REDIS_URL: redis://redis:6379/0
+      KAFKA_BROKERS: kafka:9092
+    volumes:
+      - ./:/workspace:delegated
+    working_dir: /workspace
+    depends_on:
+      db:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      kafka:
+        condition: service_started
+
+  frontend:
+    build:
+      context: ./services/frontend
+    command: ["bash", "-c", "echo 'Frontend container ready. Install dependencies and start your dev server.' && tail -f /dev/null"]
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./services/frontend:/app
+    working_dir: /app
+    depends_on:
+      - backend
+
+  db:
+    image: postgres:15
+    environment:
+      POSTGRES_DB: openia
+      POSTGRES_USER: openia
+      POSTGRES_PASSWORD: openia
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -d openia -U openia"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    build:
+      context: ./infrastructure/storage/docker/redis
+    ports:
+      - "6379:6379"
+
+  zookeeper:
+    image: bitnami/zookeeper:3.9
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: bitnami/kafka:3.6
+    depends_on:
+      - zookeeper
+    environment:
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - KAFKA_CFG_NUM_PARTITIONS=1
+      - ALLOW_PLAINTEXT_LISTENER=yes
+    ports:
+      - "9092:9092"
+    healthcheck:
+      test: ["CMD", "kafka-topics.sh", "--bootstrap-server", "localhost:9092", "--list"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 40s
+
+volumes:
+  postgres_data:

--- a/infrastructure/migrations/001_initial_schema.sql
+++ b/infrastructure/migrations/001_initial_schema.sql
@@ -1,0 +1,101 @@
+-- Migration: Initial governance, risk, and compliance schema
+-- Description: Creates core tables for risks, controls, audits, findings, timesheets, and files.
+
+BEGIN;
+
+CREATE TABLE risks (
+    id              BIGSERIAL PRIMARY KEY,
+    code            VARCHAR(50) UNIQUE NOT NULL,
+    title           VARCHAR(255) NOT NULL,
+    description     TEXT,
+    category        VARCHAR(120),
+    severity_level  VARCHAR(50) NOT NULL DEFAULT 'medium' CHECK (severity_level IN ('low', 'medium', 'high', 'critical')),
+    likelihood      VARCHAR(50),
+    impact          VARCHAR(50),
+    status          VARCHAR(50) NOT NULL DEFAULT 'identified',
+    owner           VARCHAR(255),
+    reported_on     DATE DEFAULT CURRENT_DATE,
+    mitigation_plan TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE controls (
+    id              BIGSERIAL PRIMARY KEY,
+    risk_id         BIGINT REFERENCES risks(id) ON DELETE SET NULL,
+    code            VARCHAR(50) UNIQUE NOT NULL,
+    name            VARCHAR(255) NOT NULL,
+    description     TEXT,
+    control_type    VARCHAR(120),
+    owner           VARCHAR(255),
+    status          VARCHAR(50) NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'active', 'retired')),
+    effective_date  DATE,
+    review_date     DATE,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE audits (
+    id              BIGSERIAL PRIMARY KEY,
+    code            VARCHAR(50) UNIQUE NOT NULL,
+    title           VARCHAR(255) NOT NULL,
+    description     TEXT,
+    audit_date      DATE,
+    auditor         VARCHAR(255),
+    scope           TEXT,
+    status          VARCHAR(50) NOT NULL DEFAULT 'planned' CHECK (status IN ('planned', 'in_progress', 'completed', 'archived')),
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE findings (
+    id                BIGSERIAL PRIMARY KEY,
+    audit_id          BIGINT NOT NULL REFERENCES audits(id) ON DELETE CASCADE,
+    control_id        BIGINT REFERENCES controls(id) ON DELETE SET NULL,
+    risk_id           BIGINT REFERENCES risks(id) ON DELETE SET NULL,
+    title             VARCHAR(255) NOT NULL,
+    description       TEXT,
+    severity          VARCHAR(50) NOT NULL DEFAULT 'medium' CHECK (severity IN ('low', 'medium', 'high', 'critical')),
+    status            VARCHAR(50) NOT NULL DEFAULT 'open' CHECK (status IN ('open', 'in_progress', 'mitigated', 'closed')),
+    remediation_plan  TEXT,
+    owner             VARCHAR(255),
+    due_date          DATE,
+    closed_at         TIMESTAMPTZ,
+    created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE timesheets (
+    id              BIGSERIAL PRIMARY KEY,
+    user_id         UUID NOT NULL,
+    project_code    VARCHAR(120),
+    entry_date      DATE NOT NULL,
+    hours_worked    NUMERIC(5,2) NOT NULL CHECK (hours_worked >= 0),
+    description     TEXT,
+    billable        BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (user_id, entry_date, project_code)
+);
+
+CREATE TABLE files (
+    id              BIGSERIAL PRIMARY KEY,
+    finding_id      BIGINT REFERENCES findings(id) ON DELETE CASCADE,
+    storage_provider VARCHAR(50) NOT NULL,
+    storage_path    VARCHAR(512) NOT NULL,
+    original_name   VARCHAR(255) NOT NULL,
+    content_type    VARCHAR(255),
+    size_bytes      BIGINT CHECK (size_bytes >= 0),
+    checksum        VARCHAR(128),
+    metadata        JSONB DEFAULT '{}'::JSONB,
+    uploaded_by     UUID,
+    uploaded_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_controls_risk_id ON controls (risk_id);
+CREATE INDEX idx_findings_audit_id ON findings (audit_id);
+CREATE INDEX idx_findings_control_id ON findings (control_id);
+CREATE INDEX idx_findings_risk_id ON findings (risk_id);
+CREATE INDEX idx_files_finding_id ON files (finding_id);
+
+COMMIT;

--- a/infrastructure/migrations/README.md
+++ b/infrastructure/migrations/README.md
@@ -1,0 +1,13 @@
+# Database Migrations
+
+This directory stores SQL migrations for the governance, risk, and compliance domain. Migrations are numbered to preserve the order in which they should be executed.
+
+* `001_initial_schema.sql` – creates the baseline tables for risks, controls, audits, findings, timesheets, and files along with indexes for frequent lookups.
+
+Apply migrations with your preferred tool. For example, using `psql`:
+
+```bash
+psql "$DATABASE_URL" -f infrastructure/migrations/001_initial_schema.sql
+```
+
+Always wrap migrations in transactions to keep the database consistent if any statement fails.

--- a/infrastructure/storage/README.md
+++ b/infrastructure/storage/README.md
@@ -1,0 +1,12 @@
+# Storage Stubs and Configuration
+
+This directory contains configuration templates and lightweight client stubs for integrating with cloud storage providers and message/cache infrastructure. They are intended to be replaced with production-ready implementations while keeping a consistent contract for local development and testing.
+
+## Contents
+
+- `config.example.yml` – template for environment-specific settings covering PostgreSQL, Redis, Kafka, and storage backends.
+- `s3_stub.py` – a minimal client that mimics upload/download/delete behavior against Amazon S3.
+- `blob_stub.py` – a similar stub for Azure Blob Storage.
+- `docker/` – sample Docker definitions that can be used as overrides when running Redis and Kafka locally.
+
+Copy `config.example.yml` to `config.yml` and adapt the values for your environment before running the bootstrap script.

--- a/infrastructure/storage/blob_stub.py
+++ b/infrastructure/storage/blob_stub.py
@@ -1,0 +1,66 @@
+"""Stub for Azure Blob Storage style interactions.
+
+The implementation mirrors the interface expected by the application and
+persists files to a local directory. It is intentionally lightweight so
+it can be swapped with an SDK-backed client in production.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Dict, Optional
+
+
+@dataclass
+class BlobRecord:
+    container: str
+    name: str
+    path: pathlib.Path
+    content_type: Optional[str] = None
+    uploaded_at: datetime = field(default_factory=datetime.utcnow)
+
+
+class BlobStorageStub:
+    """Simple filesystem-backed blob storage."""
+
+    def __init__(self, root: pathlib.Path):
+        self._root = root
+        self._root.mkdir(parents=True, exist_ok=True)
+        self._records: Dict[str, BlobRecord] = {}
+
+    def _identifier(self, container: str, blob_name: str) -> str:
+        return f"{container}:{blob_name}"
+
+    def upload_blob(self, data: bytes, container: str, blob_name: str, *, content_type: Optional[str] = None) -> None:
+        target_dir = self._root / container
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target_path = target_dir / blob_name
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_bytes(data)
+
+        self._records[self._identifier(container, blob_name)] = BlobRecord(
+            container=container,
+            name=blob_name,
+            path=target_path,
+            content_type=content_type,
+        )
+
+    def download_blob(self, container: str, blob_name: str) -> bytes:
+        record = self._records.get(self._identifier(container, blob_name))
+        if not record:
+            raise FileNotFoundError(f"{container}/{blob_name}")
+        return record.path.read_bytes()
+
+    def delete_blob(self, container: str, blob_name: str) -> None:
+        identifier = self._identifier(container, blob_name)
+        record = self._records.pop(identifier, None)
+        if record and record.path.exists():
+            record.path.unlink()
+
+    def list_blobs(self) -> Dict[str, BlobRecord]:
+        return dict(self._records)
+
+
+__all__ = ["BlobStorageStub", "BlobRecord"]

--- a/infrastructure/storage/config.example.yml
+++ b/infrastructure/storage/config.example.yml
@@ -1,0 +1,43 @@
+# Configuration template for infrastructure services
+# Copy to config.yml and adjust values as needed.
+
+database:
+  host: localhost
+  port: 5432
+  name: openia
+  user: openia
+  password: change_me
+  sslmode: disable
+
+redis:
+  host: localhost
+  port: 6379
+  db: 0
+  password: null
+
+kafka:
+  brokers:
+    - localhost:9092
+  client_id: openia-local
+  security_protocol: PLAINTEXT
+
+storage:
+  provider: s3  # or "azure_blob"
+  s3:
+    bucket: openia-local
+    region: us-east-1
+    access_key_id: your_access_key
+    secret_access_key: your_secret
+    endpoint_url: http://localhost:4566
+  azure_blob:
+    account_name: your_account
+    account_key: your_key
+    container: openia-local
+    endpoint_suffix: core.windows.net
+
+files:
+  max_upload_size_mb: 100
+  allowed_content_types:
+    - application/pdf
+    - application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+    - image/png

--- a/infrastructure/storage/docker/README.md
+++ b/infrastructure/storage/docker/README.md
@@ -1,0 +1,8 @@
+# Local Docker Definitions
+
+The files in this folder provide optional container definitions when you need direct access to Redis or Kafka outside of the main `docker-compose.yml` stack.
+
+- `redis/` includes a Dockerfile and configuration that extends the official Redis image with a sample configuration enabling append-only persistence.
+- `kafka/docker-compose.yml` runs a single-node Kafka cluster together with Zookeeper using Bitnami images.
+
+These resources are referenced by the root-level Compose file but can also be used independently for quick experiments.

--- a/infrastructure/storage/docker/kafka/docker-compose.yml
+++ b/infrastructure/storage/docker/kafka/docker-compose.yml
@@ -1,0 +1,21 @@
+version: "3.9"
+services:
+  zookeeper:
+    image: bitnami/zookeeper:3.9
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
+    ports:
+      - "2181:2181"
+
+  kafka:
+    image: bitnami/kafka:3.6
+    depends_on:
+      - zookeeper
+    environment:
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092
+      - KAFKA_CFG_ADVERTISED_LISTENERS=PLAINTEXT://localhost:9092
+      - KAFKA_CFG_AUTO_CREATE_TOPICS_ENABLE=true
+      - ALLOW_PLAINTEXT_LISTENER=yes
+    ports:
+      - "9092:9092"

--- a/infrastructure/storage/docker/redis/Dockerfile
+++ b/infrastructure/storage/docker/redis/Dockerfile
@@ -1,0 +1,5 @@
+FROM redis:7-alpine
+
+COPY redis.conf /usr/local/etc/redis/redis.conf
+
+CMD ["redis-server", "/usr/local/etc/redis/redis.conf"]

--- a/infrastructure/storage/docker/redis/redis.conf
+++ b/infrastructure/storage/docker/redis/redis.conf
@@ -1,0 +1,6 @@
+# Redis sample configuration for local development.
+port 6379
+bind 0.0.0.0
+protected-mode no
+dir /data
+appendonly yes

--- a/infrastructure/storage/s3_stub.py
+++ b/infrastructure/storage/s3_stub.py
@@ -1,0 +1,98 @@
+"""Lightweight S3 client stub for local development.
+
+This module mimics a subset of boto3's S3 client interface so the
+application can be exercised without requiring AWS credentials. The
+implementation keeps uploaded files in a local directory and records
+metadata for inspection during tests.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Dict, Optional
+
+
+@dataclass
+class S3Object:
+    """Representation of an object tracked by the stub."""
+
+    bucket: str
+    key: str
+    path: pathlib.Path
+    content_type: Optional[str] = None
+    size_bytes: int = 0
+    metadata: Dict[str, str] = field(default_factory=dict)
+    uploaded_at: datetime = field(default_factory=datetime.utcnow)
+
+
+class S3StubClient:
+    """Tiny S3 client that operates on the local filesystem."""
+
+    def __init__(self, storage_dir: pathlib.Path):
+        self._storage_dir = storage_dir
+        self._storage_dir.mkdir(parents=True, exist_ok=True)
+        self._objects: Dict[str, S3Object] = {}
+
+    def _object_id(self, bucket: str, key: str) -> str:
+        return f"{bucket}:{key}"
+
+    def upload_file(self, filename: str, bucket: str, key: str, ExtraArgs: Optional[Dict[str, str]] = None) -> None:  # noqa: N803 (match boto3 casing)
+        """Store a file in the stub's local directory."""
+
+        file_path = pathlib.Path(filename)
+        if not file_path.exists():
+            raise FileNotFoundError(filename)
+
+        target_dir = self._storage_dir / bucket
+        target_dir.mkdir(parents=True, exist_ok=True)
+        target_path = target_dir / key
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_bytes(file_path.read_bytes())
+
+        metadata = ExtraArgs or {}
+        obj = S3Object(
+            bucket=bucket,
+            key=key,
+            path=target_path,
+            content_type=metadata.get("ContentType"),
+            size_bytes=target_path.stat().st_size,
+            metadata={k: v for k, v in metadata.items() if k != "ContentType"},
+        )
+        self._objects[self._object_id(bucket, key)] = obj
+
+    def download_file(self, bucket: str, key: str, filename: str) -> None:
+        """Write the stored object to the requested file path."""
+
+        obj = self._objects.get(self._object_id(bucket, key))
+        if not obj:
+            raise FileNotFoundError(f"{bucket}/{key}")
+
+        target_path = pathlib.Path(filename)
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        target_path.write_bytes(obj.path.read_bytes())
+
+    def delete_object(self, bucket: str, key: str) -> None:
+        """Remove the object if it exists."""
+
+        identifier = self._object_id(bucket, key)
+        obj = self._objects.pop(identifier, None)
+        if obj and obj.path.exists():
+            obj.path.unlink()
+
+    def generate_presigned_url(self, bucket: str, key: str, expires_in: int = 3600) -> str:
+        """Return a deterministic pseudo-URL for the object."""
+
+        expiry = datetime.utcnow() + timedelta(seconds=expires_in)
+        token = json.dumps({"bucket": bucket, "key": key, "expires_at": expiry.isoformat()})
+        return f"https://example.com/s3/{bucket}/{key}?stub-token={token}"
+
+    def list_objects(self) -> Dict[str, S3Object]:
+        """Expose stored objects for assertions in tests."""
+
+        return dict(self._objects)
+
+
+__all__ = ["S3StubClient", "S3Object"]

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+show_help() {
+  cat <<'USAGE'
+Usage: bootstrap.sh [--skip-containers] [--ci]
+
+Prepares the repository for local development by ensuring configuration files
+exist and optionally starting supporting services defined in docker-compose.yml.
+
+Options:
+  --skip-containers   Do not attempt to start Docker services.
+  --ci                Alias for --skip-containers, used by automation.
+  -h, --help          Display this help message.
+USAGE
+}
+
+SKIP_CONTAINERS=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --skip-containers)
+      SKIP_CONTAINERS=true
+      ;;
+    --ci)
+      SKIP_CONTAINERS=true
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      show_help
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+CONFIG_TEMPLATE="$ROOT_DIR/infrastructure/storage/config.example.yml"
+CONFIG_FILE="$ROOT_DIR/infrastructure/storage/config.yml"
+
+if [[ -f "$CONFIG_TEMPLATE" && ! -f "$CONFIG_FILE" ]]; then
+  cp "$CONFIG_TEMPLATE" "$CONFIG_FILE"
+  echo "Created infrastructure/storage/config.yml from template."
+else
+  echo "Configuration template already applied or missing."
+fi
+
+if [[ "$SKIP_CONTAINERS" == true ]]; then
+  echo "Skipping Docker container startup."
+  exit 0
+fi
+
+COMPOSE_CMD=""
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  COMPOSE_CMD="docker compose"
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE_CMD="docker-compose"
+fi
+
+if [[ -z "$COMPOSE_CMD" ]]; then
+  echo "Docker Compose is not installed; skipping container startup."
+  exit 0
+fi
+
+echo "Pulling infrastructure images..."
+$COMPOSE_CMD pull db redis kafka zookeeper >/dev/null 2>&1 || true
+
+echo "Starting core infrastructure services (db, redis, kafka, zookeeper)..."
+$COMPOSE_CMD up -d db redis zookeeper kafka
+
+echo "Bootstrap complete. Use 'docker compose up' to start application containers."

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+show_help() {
+  cat <<'USAGE'
+Usage: test.sh [--ci]
+
+Runs lightweight validation checks used for CI and local development.
+  --ci    Enable CI-friendly defaults (skip Docker-based checks that require services).
+  -h      Display this help message.
+USAGE
+}
+
+CI_MODE=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --ci)
+      CI_MODE=true
+      ;;
+    -h|--help)
+      show_help
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      show_help
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+
+echo "==> Checking shell scripts syntax"
+bash -n "$ROOT_DIR/scripts/bootstrap.sh"
+bash -n "$ROOT_DIR/scripts/test.sh"
+
+echo "==> Compiling Python storage stubs"
+if command -v python3 >/dev/null 2>&1; then
+  python3 -m compileall "$ROOT_DIR/infrastructure/storage"
+else
+  echo "python3 is not available; skipping Python compilation."
+fi
+
+echo "==> Validating docker-compose configuration"
+COMPOSE_CMD=""
+if command -v docker >/dev/null 2>&1 && docker compose version >/dev/null 2>&1; then
+  COMPOSE_CMD="docker compose"
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE_CMD="docker-compose"
+fi
+
+if [[ -n "$COMPOSE_CMD" ]]; then
+  if [[ "$CI_MODE" == true ]]; then
+    $COMPOSE_CMD config -q
+  else
+    $COMPOSE_CMD config
+  fi
+else
+  echo "Docker Compose not found; skipping Compose validation."
+fi
+
+echo "==> Dry-run database migrations"
+PSQL_BIN=$(command -v psql 2>/dev/null || true)
+if [[ -n "${DATABASE_URL:-}" && -n "$PSQL_BIN" ]]; then
+  for migration in "$ROOT_DIR"/infrastructure/migrations/*.sql; do
+    echo "Checking $migration"
+    "$PSQL_BIN" "$DATABASE_URL" -v ON_ERROR_STOP=1 -f "$migration" >/dev/null
+  done
+else
+  echo "DATABASE_URL not set or psql unavailable; skipped migration execution."
+fi
+
+echo "All checks completed."

--- a/services/backend/Dockerfile
+++ b/services/backend/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . ./
+
+CMD ["bash", "-c", "echo 'Backend base image ready. Override CMD to run your app.' && tail -f /dev/null"]

--- a/services/backend/README.md
+++ b/services/backend/README.md
@@ -1,0 +1,5 @@
+# Backend Service Stub
+
+This directory provides a minimal Docker build context for API and background services. It installs dependencies from `requirements.txt` and leaves the container running so you can attach and start your preferred application server manually during local development.
+
+Replace the placeholder command in the root `docker-compose.yml` with the entrypoint for your framework (e.g., Django, FastAPI, Express).

--- a/services/backend/requirements.txt
+++ b/services/backend/requirements.txt
@@ -1,0 +1,1 @@
+# Add backend Python dependencies here.

--- a/services/frontend/Dockerfile
+++ b/services/frontend/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+COPY package.json ./
+RUN npm install --silent
+
+COPY . ./
+
+CMD ["npm", "run", "dev"]

--- a/services/frontend/README.md
+++ b/services/frontend/README.md
@@ -1,0 +1,3 @@
+# Frontend Container Stub
+
+This directory contains a placeholder Node.js application that simply keeps the container alive. Swap `server.js` and the npm scripts with your actual frontend tooling (React, Vue, etc.) as needed. The root `docker-compose.yml` exposes port 3000 for local development.

--- a/services/frontend/package.json
+++ b/services/frontend/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "openia-frontend-stub",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "node server.js",
+    "lint": "echo \"No frontend lint configured.\""
+  },
+  "dependencies": {}
+}

--- a/services/frontend/server.js
+++ b/services/frontend/server.js
@@ -1,0 +1,9 @@
+// Minimal frontend development stub.
+// Replace with your preferred tooling (Vite, Next.js, etc.).
+
+console.log('Frontend development container is running.');
+console.log('Update server.js or swap in your actual dev server command.');
+
+setInterval(() => {
+  console.log('Frontend stub heartbeat - replace with real app.');
+}, 60000);


### PR DESCRIPTION
## Summary
- add initial PostgreSQL schema migration for GRC domain entities and documentation
- provide storage client stubs, configuration templates, and local Redis/Kafka docker assets
- create docker-compose stack, dev service Dockerfiles, scripts, and CI pipeline to bootstrap and test the project

## Testing
- `./scripts/bootstrap.sh --ci`
- `./scripts/test.sh --ci`


------
https://chatgpt.com/codex/tasks/task_e_68cdbbb791648328b50b1e7e3272a887