### PR TITLE
feat: scaffold React risk management frontend

### DIFF
--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>OpenIA Assurance Suite</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/jest.config.ts
+++ b/frontend/jest.config.ts
@@ -1,0 +1,23 @@
+import type { Config } from 'jest';
+
+const config: Config = {
+  preset: 'ts-jest/presets/js-with-ts-esm',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
+  moduleNameMapper: {
+    '\\.(css|less|scss)$': '<rootDir>/src/__mocks__/styleMock.ts'
+  },
+  transform: {
+    '^.+\\.(ts|tsx)$': [
+      'ts-jest',
+      {
+        useESM: true,
+        tsconfig: '<rootDir>/tsconfig.json'
+      }
+    ]
+  },
+  extensionsToTreatAsEsm: ['.ts', '.tsx'],
+  testPathIgnorePatterns: ['/node_modules/', '/dist/']
+};
+
+export default config;

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "openia-frontend",
+  "private": true,
+  "version": "0.1.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build",
+    "preview": "vite preview",
+    "test": "jest"
+  },
+  "dependencies": {
+    "chart.js": "^4.4.2",
+    "d3": "^7.8.5",
+    "react": "^18.2.0",
+    "react-chartjs-2": "^5.2.0",
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.3"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.2.0",
+    "@testing-library/react": "^14.2.1",
+    "@testing-library/user-event": "^14.5.2",
+    "@types/jest": "^29.5.12",
+    "@types/node": "^20.11.30",
+    "@types/react": "^18.2.64",
+    "@types/react-dom": "^18.2.18",
+    "@vitejs/plugin-react": "^4.2.1",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.1.2",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.4.3",
+    "vite": "^5.1.4",
+    "whatwg-fetch": "^3.6.20"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
+import { AuthProvider } from './context/AuthContext';
+import { RoleBasedLayout } from './layouts/RoleBasedLayout';
+import { RiskDashboard } from './pages/RiskDashboard';
+import { RiskIdentificationQuestionnaire } from './pages/RiskIdentificationQuestionnaire';
+import { RiskMatrix } from './pages/RiskMatrix';
+import { AuditPlanning } from './pages/AuditPlanning';
+import { Timesheets } from './pages/Timesheets';
+import { WorkingPapers } from './pages/WorkingPapers';
+import { FollowUpTracker } from './pages/FollowUpTracker';
+import { Reporting } from './pages/Reporting';
+
+const NotFound: React.FC = () => (
+  <div>
+    <h1>Page not found</h1>
+    <p>The requested resource could not be located.</p>
+  </div>
+);
+
+const AppRoutes: React.FC = () => (
+  <Routes>
+    <Route path="/" element={<Navigate to="/risks/dashboard" replace />} />
+    <Route path="/risks/dashboard" element={<RiskDashboard />} />
+    <Route path="/risks/questionnaire" element={<RiskIdentificationQuestionnaire />} />
+    <Route path="/risks/matrix" element={<RiskMatrix />} />
+    <Route path="/audits/planning" element={<AuditPlanning />} />
+    <Route path="/audits/timesheets" element={<Timesheets />} />
+    <Route path="/audits/working-papers" element={<WorkingPapers />} />
+    <Route path="/risks/follow-up" element={<FollowUpTracker />} />
+    <Route path="/reports" element={<Reporting />} />
+    <Route path="*" element={<NotFound />} />
+  </Routes>
+);
+
+const App: React.FC = () => (
+  <AuthProvider>
+    <RoleBasedLayout>
+      <AppRoutes />
+    </RoleBasedLayout>
+  </AuthProvider>
+);
+
+export default App;

--- a/frontend/src/__mocks__/styleMock.ts
+++ b/frontend/src/__mocks__/styleMock.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/frontend/src/__tests__/App.test.tsx
+++ b/frontend/src/__tests__/App.test.tsx
@@ -1,0 +1,95 @@
+import React from 'react';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter } from 'react-router-dom';
+import App from '../App';
+
+const createResponse = (body: unknown, init?: ResponseInit) =>
+  Promise.resolve(
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+      ...init
+    })
+  );
+
+describe('App', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    window.localStorage.clear();
+  });
+
+  it('shows the sign-in form when unauthenticated', async () => {
+    jest.spyOn(global, 'fetch').mockImplementation((input) => {
+      const url = typeof input === 'string' ? input : input.url;
+      if (url.endsWith('/auth/me')) {
+        return Promise.resolve(new Response('Unauthorized', { status: 401 }));
+      }
+      return createResponse({});
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/risks/dashboard']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { name: /sign in to the openia assurance suite/i })).toBeInTheDocument();
+  });
+
+  it('authenticates and renders the risk dashboard', async () => {
+    jest.spyOn(global, 'fetch').mockImplementation((input, init) => {
+      const url = typeof input === 'string' ? input : input.url;
+      if (url.endsWith('/auth/me')) {
+        return Promise.resolve(new Response('Unauthorized', { status: 401 }));
+      }
+      if (url.endsWith('/auth/login')) {
+        return createResponse({
+          token: 'test-token',
+          user: {
+            id: 'user-1',
+            name: 'Test Admin',
+            email: 'admin@example.com',
+            role: 'admin'
+          }
+        });
+      }
+      if (url.includes('/risks/summary')) {
+        return createResponse({
+          totalRisks: 3,
+          highRisks: 1,
+          mediumRisks: 1,
+          lowRisks: 1,
+          trend: [
+            { month: 'Jan', high: 1, medium: 1, low: 1 }
+          ]
+        });
+      }
+      if (url.includes('/risks?')) {
+        return createResponse([
+          { id: 'r1', title: 'Risk 1', category: 'Financial', inherentRisk: 4, residualRisk: 3, owner: 'Owner', status: 'open' }
+        ]);
+      }
+      return createResponse([]);
+    });
+
+    render(
+      <MemoryRouter initialEntries={['/risks/dashboard']}>
+        <App />
+      </MemoryRouter>
+    );
+
+    expect(await screen.findByRole('heading', { name: /sign in/i })).toBeInTheDocument();
+
+    await userEvent.type(screen.getByLabelText(/email/i), 'admin@example.com');
+    await userEvent.type(screen.getByLabelText(/password/i), 'password123');
+    await userEvent.click(screen.getByRole('button', { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /risk dashboard/i })).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/total risks/i)).toBeInTheDocument();
+    expect(window.localStorage.getItem('openia.jwt')).toBe('test-token');
+  });
+});

--- a/frontend/src/__tests__/RiskDashboard.test.tsx
+++ b/frontend/src/__tests__/RiskDashboard.test.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { RiskDashboard } from '../pages/RiskDashboard';
+
+jest.mock('../api/risks', () => ({
+  useRiskSummary: () => ({
+    summary: {
+      totalRisks: 10,
+      highRisks: 4,
+      mediumRisks: 3,
+      lowRisks: 3,
+      trend: [
+        { month: 'Jan', high: 2, medium: 1, low: 1 },
+        { month: 'Feb', high: 1, medium: 1, low: 1 },
+        { month: 'Mar', high: 1, medium: 1, low: 1 }
+      ]
+    },
+    isLoading: false,
+    error: null,
+    refresh: jest.fn()
+  }),
+  useRisks: () => ({
+    risks: [
+      { id: '1', title: 'Risk', category: 'Operational', inherentRisk: 4, residualRisk: 3, owner: 'Owner', status: 'open' }
+    ],
+    isLoading: false,
+    error: null,
+    refresh: jest.fn()
+  }),
+  useRiskQuestionnaire: jest.fn(),
+  useFollowUpItems: jest.fn()
+}));
+
+describe('RiskDashboard', () => {
+  it('renders key metrics and charts', () => {
+    render(<RiskDashboard />);
+    expect(screen.getByRole('heading', { name: /risk dashboard/i })).toBeInTheDocument();
+    expect(screen.getByRole('article', { name: /total risks/i })).toBeInTheDocument();
+    expect(screen.getByRole('article', { name: /risk trend chart/i })).toBeInTheDocument();
+    expect(screen.getByRole('article', { name: /risk distribution chart/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/src/__tests__/apiHooks.test.tsx
+++ b/frontend/src/__tests__/apiHooks.test.tsx
@@ -1,0 +1,69 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useAuthApi } from '../api/auth';
+import { getToken } from '../api/client';
+import { useRisks } from '../api/risks';
+
+const createResponse = (body: unknown, init?: ResponseInit) =>
+  Promise.resolve(
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+      ...init
+    })
+  );
+
+describe('API hooks', () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    window.localStorage.clear();
+  });
+
+  it('logs in and stores the JWT token', async () => {
+    jest.spyOn(global, 'fetch').mockImplementation((input) => {
+      const url = typeof input === 'string' ? input : input.url;
+      if (url.endsWith('/auth/login')) {
+        return createResponse({
+          token: 'jwt-token',
+          user: { id: '1', name: 'Tester', email: 't@example.com', role: 'admin' }
+        });
+      }
+      return createResponse({});
+    });
+
+    const { result } = renderHook(() => useAuthApi());
+
+    await act(async () => {
+      const user = await result.current.login({ email: 't@example.com', password: 'secret' });
+      expect(user.email).toBe('t@example.com');
+    });
+
+    expect(getToken()).toBe('jwt-token');
+
+    act(() => {
+      result.current.logout();
+    });
+
+    expect(getToken()).toBeNull();
+  });
+
+  it('fetches risks with status filters', async () => {
+    const fetchMock = jest.spyOn(global, 'fetch').mockImplementation((input) => {
+      const url = typeof input === 'string' ? input : input.url;
+      if (url.includes('/risks?status=open')) {
+        return createResponse([
+          { id: 'risk-1', title: 'Risk 1', category: 'Operational', inherentRisk: 3, residualRisk: 2, owner: 'Owner', status: 'open' }
+        ]);
+      }
+      return createResponse([]);
+    });
+
+    const { result } = renderHook(() => useRisks({ status: 'open' }));
+
+    await waitFor(() => {
+      expect(result.current.isLoading).toBe(false);
+    });
+
+    expect(result.current.risks).toHaveLength(1);
+    expect(fetchMock).toHaveBeenCalledWith(expect.stringContaining('/risks?status=open'), expect.anything());
+  });
+});

--- a/frontend/src/api/audits.ts
+++ b/frontend/src/api/audits.ts
@@ -1,0 +1,113 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { apiClient } from './client';
+import type { AuditPlan, TimesheetEntry, WorkingPaper } from '../types';
+
+export const useAuditPlans = () => {
+  const [plans, setPlans] = useState<AuditPlan[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const response = await apiClient.get<AuditPlan[]>('/audits');
+      setPlans(response);
+      setError(null);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const createPlan = useCallback(async (plan: Partial<AuditPlan>) => {
+    const response = await apiClient.post<AuditPlan>('/audits', plan);
+    await refresh();
+    return response;
+  }, [refresh]);
+
+  const updatePlanStatus = useCallback(async (id: string, status: AuditPlan['status']) => {
+    const response = await apiClient.patch<AuditPlan>(`/audits/${id}`, { status });
+    await refresh();
+    return response;
+  }, [refresh]);
+
+  return useMemo(
+    () => ({ plans, isLoading, error, refresh, createPlan, updatePlanStatus }),
+    [plans, isLoading, error, refresh, createPlan, updatePlanStatus]
+  );
+};
+
+export const useTimesheets = (auditor?: string) => {
+  const [entries, setEntries] = useState<TimesheetEntry[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const query = auditor ? `?auditor=${encodeURIComponent(auditor)}` : '';
+      const response = await apiClient.get<TimesheetEntry[]>(`/audits/timesheets${query}`);
+      setEntries(response);
+      setError(null);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [auditor]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const submitEntry = useCallback(async (entry: Partial<TimesheetEntry>) => {
+    const response = await apiClient.post<TimesheetEntry>('/audits/timesheets', entry);
+    await refresh();
+    return response;
+  }, [refresh]);
+
+  return useMemo(
+    () => ({ entries, isLoading, error, refresh, submitEntry }),
+    [entries, isLoading, error, refresh, submitEntry]
+  );
+};
+
+export const useWorkingPapers = (auditId?: string) => {
+  const [papers, setPapers] = useState<WorkingPaper[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const query = auditId ? `?auditId=${encodeURIComponent(auditId)}` : '';
+      const response = await apiClient.get<WorkingPaper[]>(`/audits/working-papers${query}`);
+      setPapers(response);
+      setError(null);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [auditId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const updateStatus = useCallback(async (id: string, status: WorkingPaper['status']) => {
+    const response = await apiClient.patch<WorkingPaper>(`/audits/working-papers/${id}`, { status });
+    await refresh();
+    return response;
+  }, [refresh]);
+
+  return useMemo(
+    () => ({ papers, isLoading, error, refresh, updateStatus }),
+    [papers, isLoading, error, refresh, updateStatus]
+  );
+};

--- a/frontend/src/api/auth.ts
+++ b/frontend/src/api/auth.ts
@@ -1,0 +1,34 @@
+import { useCallback } from 'react';
+import { apiClient, clearToken, setToken, withErrorBoundary } from './client';
+import type { AuthenticatedUser } from '../types';
+
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  token: string;
+  user: AuthenticatedUser;
+}
+
+export const useAuthApi = () => {
+  const login = useCallback(async (payload: LoginRequest) => {
+    const response = await apiClient.post<LoginResponse>('/auth/login', payload, { auth: false });
+    setToken(response.token);
+    return response.user;
+  }, []);
+
+  const fetchCurrentUser = useCallback(async () => {
+    return withErrorBoundary<AuthenticatedUser | null>(
+      apiClient.get<AuthenticatedUser>('/auth/me'),
+      null
+    );
+  }, []);
+
+  const logout = useCallback(() => {
+    clearToken();
+  }, []);
+
+  return { login, logout, fetchCurrentUser };
+};

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,134 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? 'http://localhost:4000';
+const TOKEN_STORAGE_KEY = 'openia.jwt';
+
+let inMemoryToken: string | null = null;
+
+type SerializableBody = BodyInit | Record<string, unknown> | null | undefined;
+
+const getBrowserStorage = () => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+  try {
+    return window.localStorage;
+  } catch (error) {
+    console.warn('LocalStorage is not available, falling back to in-memory token storage.', error);
+    return null;
+  }
+};
+
+export const getToken = () => {
+  const storage = getBrowserStorage();
+  if (storage) {
+    return storage.getItem(TOKEN_STORAGE_KEY);
+  }
+  return inMemoryToken;
+};
+
+export const setToken = (token: string | null) => {
+  const storage = getBrowserStorage();
+  if (storage) {
+    if (token) {
+      storage.setItem(TOKEN_STORAGE_KEY, token);
+    } else {
+      storage.removeItem(TOKEN_STORAGE_KEY);
+    }
+  }
+  inMemoryToken = token;
+};
+
+export interface RequestOptions extends RequestInit {
+  auth?: boolean;
+  body?: SerializableBody;
+}
+
+export class ApiError extends Error {
+  public status: number;
+  public details?: unknown;
+
+  constructor(message: string, status: number, details?: unknown) {
+    super(message);
+    this.status = status;
+    this.details = details;
+  }
+}
+
+const buildHeaders = (options: RequestOptions) => {
+  const headers = new Headers(options.headers || {});
+  headers.set('Accept', 'application/json');
+  if (options.body && !(options.body instanceof FormData)) {
+    headers.set('Content-Type', 'application/json');
+  }
+
+  if (options.auth !== false) {
+    const token = getToken();
+    if (token) {
+      headers.set('Authorization', `Bearer ${token}`);
+    }
+  }
+
+  return headers;
+};
+
+const serialiseBody = (body: SerializableBody) => {
+  if (!body) {
+    return undefined;
+  }
+  if (
+    body instanceof FormData ||
+    body instanceof Blob ||
+    body instanceof URLSearchParams ||
+    typeof body === 'string'
+  ) {
+    return body as BodyInit;
+  }
+  return JSON.stringify(body);
+};
+
+const handleResponse = async <T>(response: Response): Promise<T> => {
+  const contentType = response.headers.get('content-type');
+  const isJson = contentType?.includes('application/json');
+  const payload = isJson ? await response.json() : await response.text();
+
+  if (!response.ok) {
+    throw new ApiError(
+      response.statusText || 'Request failed',
+      response.status,
+      payload
+    );
+  }
+
+  return payload as T;
+};
+
+const request = async <T>(path: string, options: RequestOptions = {}) => {
+  const headers = buildHeaders(options);
+  const body = serialiseBody(options.body);
+
+  const response = await fetch(`${API_BASE_URL}${path}`, {
+    ...options,
+    headers,
+    body
+  });
+
+  return handleResponse<T>(response);
+};
+
+export const apiClient = {
+  get: <T>(path: string, options: RequestOptions = {}) => request<T>(path, { ...options, method: 'GET' }),
+  post: <T>(path: string, body?: SerializableBody, options: RequestOptions = {}) => request<T>(path, { ...options, method: 'POST', body }),
+  put: <T>(path: string, body?: SerializableBody, options: RequestOptions = {}) => request<T>(path, { ...options, method: 'PUT', body }),
+  patch: <T>(path: string, body?: SerializableBody, options: RequestOptions = {}) => request<T>(path, { ...options, method: 'PATCH', body }),
+  delete: <T>(path: string, options: RequestOptions = {}) => request<T>(path, { ...options, method: 'DELETE' })
+};
+
+export const clearToken = () => setToken(null);
+
+export const withErrorBoundary = async <T>(promise: Promise<T>, fallback: T): Promise<T> => {
+  try {
+    return await promise;
+  } catch (error) {
+    console.error('API request failed', error);
+    return fallback;
+  }
+};

--- a/frontend/src/api/reports.ts
+++ b/frontend/src/api/reports.ts
@@ -1,0 +1,80 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { apiClient } from './client';
+import type { ReportSummary } from '../types';
+
+interface ReportFilters {
+  status?: ReportSummary['status'];
+  owner?: string;
+}
+
+export const useReports = (filters?: ReportFilters) => {
+  const [reports, setReports] = useState<ReportSummary[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const params = new URLSearchParams();
+      if (filters?.status) params.set('status', filters.status);
+      if (filters?.owner) params.set('owner', filters.owner);
+      const query = params.toString() ? `?${params.toString()}` : '';
+      const response = await apiClient.get<ReportSummary[]>(`/reports${query}`);
+      setReports(response);
+      setError(null);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [filters?.owner, filters?.status]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const generateReport = useCallback(async (reportId: string) => {
+    const response = await apiClient.post<ReportSummary>(`/reports/${reportId}/generate`);
+    await refresh();
+    return response;
+  }, [refresh]);
+
+  return useMemo(
+    () => ({ reports, isLoading, error, refresh, generateReport }),
+    [reports, isLoading, error, refresh, generateReport]
+  );
+};
+
+export const useReportDetails = (reportId?: string) => {
+  const [report, setReport] = useState<ReportSummary | null>(null);
+  const [isLoading, setIsLoading] = useState(Boolean(reportId));
+  const [error, setError] = useState<Error | null>(null);
+
+  const refresh = useCallback(async () => {
+    if (!reportId) {
+      setReport(null);
+      setIsLoading(false);
+      return;
+    }
+
+    setIsLoading(true);
+    try {
+      const response = await apiClient.get<ReportSummary>(`/reports/${reportId}`);
+      setReport(response);
+      setError(null);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [reportId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return useMemo(
+    () => ({ report, isLoading, error, refresh }),
+    [report, isLoading, error, refresh]
+  );
+};

--- a/frontend/src/api/risks.ts
+++ b/frontend/src/api/risks.ts
@@ -1,0 +1,115 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { apiClient } from './client';
+import type { FollowUpItem, QuestionnaireResponse, Risk, RiskSummary } from '../types';
+
+const buildQueryString = (params?: Record<string, string | number | undefined>) => {
+  if (!params) {
+    return '';
+  }
+
+  const query = Object.entries(params)
+    .filter(([, value]) => value !== undefined && value !== '')
+    .map(([key, value]) => `${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`)
+    .join('&');
+
+  return query ? `?${query}` : '';
+};
+
+export const useRiskSummary = () => {
+  const [summary, setSummary] = useState<RiskSummary | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const response = await apiClient.get<RiskSummary>('/risks/summary');
+      setSummary(response);
+      setError(null);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return useMemo(
+    () => ({ summary, isLoading, error, refresh }),
+    [summary, isLoading, error, refresh]
+  );
+};
+
+export interface UseRisksOptions {
+  status?: Risk['status'];
+  owner?: string;
+}
+
+export const useRisks = (options?: UseRisksOptions) => {
+  const [risks, setRisks] = useState<Risk[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const query = buildQueryString(options);
+      const response = await apiClient.get<Risk[]>(`/risks${query}`);
+      setRisks(response);
+      setError(null);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [options?.owner, options?.status]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return useMemo(
+    () => ({ risks, isLoading, error, refresh }),
+    [risks, isLoading, error, refresh]
+  );
+};
+
+export const useRiskQuestionnaire = () => {
+  const submit = useCallback(async (payload: QuestionnaireResponse) => {
+    return apiClient.post<Risk>(`/risks/${payload.riskId ?? 'new'}/questionnaire`, payload);
+  }, []);
+
+  return { submit };
+};
+
+export const useFollowUpItems = (riskId?: string) => {
+  const [items, setItems] = useState<FollowUpItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<Error | null>(null);
+
+  const refresh = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      const query = buildQueryString({ riskId });
+      const response = await apiClient.get<FollowUpItem[]>(`/risks/follow-ups${query}`);
+      setItems(response);
+      setError(null);
+    } catch (err) {
+      setError(err as Error);
+    } finally {
+      setIsLoading(false);
+    }
+  }, [riskId]);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return useMemo(
+    () => ({ items, isLoading, error, refresh }),
+    [items, isLoading, error, refresh]
+  );
+};

--- a/frontend/src/components/LoginForm.tsx
+++ b/frontend/src/components/LoginForm.tsx
@@ -1,0 +1,55 @@
+import React, { useState } from 'react';
+import type { LoginRequest } from '../api/auth';
+
+interface LoginFormProps {
+  onSubmit: (payload: LoginRequest) => Promise<void>;
+  isLoading?: boolean;
+  errorMessage?: string | null;
+}
+
+export const LoginForm: React.FC<LoginFormProps> = ({ onSubmit, isLoading = false, errorMessage }) => {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    await onSubmit({ email, password });
+  };
+
+  return (
+    <form onSubmit={handleSubmit} aria-describedby={errorMessage ? 'login-error' : undefined}>
+      <div className="form-grid">
+        <div className="form-control">
+          <label htmlFor="email">Email</label>
+          <input
+            id="email"
+            type="email"
+            autoComplete="email"
+            value={email}
+            onChange={(event) => setEmail(event.target.value)}
+            required
+          />
+        </div>
+        <div className="form-control">
+          <label htmlFor="password">Password</label>
+          <input
+            id="password"
+            type="password"
+            autoComplete="current-password"
+            value={password}
+            onChange={(event) => setPassword(event.target.value)}
+            required
+          />
+        </div>
+      </div>
+      {errorMessage ? (
+        <p id="login-error" role="alert" style={{ color: '#b91c1c' }}>
+          {errorMessage}
+        </p>
+      ) : null}
+      <button type="submit" disabled={isLoading} style={{ marginTop: '1rem' }}>
+        {isLoading ? 'Signing in…' : 'Sign in'}
+      </button>
+    </form>
+  );
+};

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,0 +1,82 @@
+import React, { createContext, useCallback, useContext, useEffect, useMemo, useState } from 'react';
+import type { AuthenticatedUser, UserRole } from '../types';
+import { useAuthApi, type LoginRequest } from '../api/auth';
+
+interface AuthContextValue {
+  user: AuthenticatedUser | null;
+  isLoading: boolean;
+  login: (payload: LoginRequest) => Promise<void>;
+  logout: () => void;
+  hasRole: (role: UserRole | UserRole[]) => boolean;
+}
+
+const AuthContext = createContext<AuthContextValue | undefined>(undefined);
+
+export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { login: loginApi, logout: logoutApi, fetchCurrentUser } = useAuthApi();
+  const [user, setUser] = useState<AuthenticatedUser | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  useEffect(() => {
+    let isMounted = true;
+    const load = async () => {
+      setIsLoading(true);
+      try {
+        const current = await fetchCurrentUser();
+        if (isMounted) {
+          setUser(current);
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    void load();
+
+    return () => {
+      isMounted = false;
+    };
+  }, [fetchCurrentUser]);
+
+  const login = useCallback(async (payload: LoginRequest) => {
+    const nextUser = await loginApi(payload);
+    setUser(nextUser);
+  }, [loginApi]);
+
+  const logout = useCallback(() => {
+    logoutApi();
+    setUser(null);
+  }, [logoutApi]);
+
+  const value = useMemo<AuthContextValue>(() => ({
+    user,
+    isLoading,
+    login,
+    logout,
+    hasRole: (role: UserRole | UserRole[]) => {
+      const roles = Array.isArray(role) ? role : [role];
+      return user ? roles.includes(user.role) : false;
+    }
+  }), [user, isLoading, login, logout]);
+
+  return (
+    <AuthContext.Provider value={value}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};
+
+export const useRole = () => {
+  const { user } = useAuth();
+  return user?.role ?? null;
+};

--- a/frontend/src/layouts/AdminLayout.tsx
+++ b/frontend/src/layouts/AdminLayout.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { LayoutShell, type NavItem } from './LayoutShell';
+import type { AuthenticatedUser } from '../types';
+
+interface AdminLayoutProps {
+  user: AuthenticatedUser;
+  onLogout: () => void;
+  children: React.ReactNode;
+}
+
+const navItems: NavItem[] = [
+  { label: 'Risk Dashboard', description: 'Real-time risk overview', to: '/risks/dashboard' },
+  { label: 'Risk Identification', description: 'Questionnaire intake', to: '/risks/questionnaire' },
+  { label: 'Risk Matrix', description: 'Visualise likelihood & impact', to: '/risks/matrix' },
+  { label: 'Audit Planning', description: 'Engagement roadmap', to: '/audits/planning' },
+  { label: 'Timesheets', description: 'Track auditor utilisation', to: '/audits/timesheets' },
+  { label: 'Working Papers', description: 'Document fieldwork', to: '/audits/working-papers' },
+  { label: 'Follow-up Tracker', description: 'Monitor remediation progress', to: '/risks/follow-up' },
+  { label: 'Reporting', description: 'Publish executive insights', to: '/reports' }
+];
+
+export const AdminLayout: React.FC<AdminLayoutProps> = ({ user, onLogout, children }) => (
+  <LayoutShell
+    title="Enterprise Risk Control Center"
+    subtitle="Administrator workspace"
+    navItems={navItems}
+    userName={user.name}
+    role={user.role}
+    onLogout={onLogout}
+  >
+    {children}
+  </LayoutShell>
+);

--- a/frontend/src/layouts/AuditorLayout.tsx
+++ b/frontend/src/layouts/AuditorLayout.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+import { LayoutShell, type NavItem } from './LayoutShell';
+import type { AuthenticatedUser } from '../types';
+
+interface AuditorLayoutProps {
+  user: AuthenticatedUser;
+  onLogout: () => void;
+  children: React.ReactNode;
+}
+
+const navItems: NavItem[] = [
+  { label: 'Risk Dashboard', description: 'Portfolio trends', to: '/risks/dashboard' },
+  { label: 'Audit Planning', description: 'Engagement roadmap', to: '/audits/planning' },
+  { label: 'Timesheets', description: 'Capture effort', to: '/audits/timesheets' },
+  { label: 'Working Papers', description: 'Evidence repository', to: '/audits/working-papers' },
+  { label: 'Follow-up Tracker', description: 'Remediation visibility', to: '/risks/follow-up' }
+];
+
+export const AuditorLayout: React.FC<AuditorLayoutProps> = ({ user, onLogout, children }) => (
+  <LayoutShell
+    title="Audit Delivery Center"
+    subtitle="Auditor toolkit"
+    navItems={navItems}
+    userName={user.name}
+    role={user.role}
+    onLogout={onLogout}
+  >
+    {children}
+  </LayoutShell>
+);

--- a/frontend/src/layouts/LayoutShell.tsx
+++ b/frontend/src/layouts/LayoutShell.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { NavLink } from 'react-router-dom';
+import type { UserRole } from '../types';
+
+export interface NavItem {
+  label: string;
+  description?: string;
+  to: string;
+}
+
+interface LayoutShellProps {
+  title: string;
+  subtitle?: string;
+  navItems: NavItem[];
+  userName?: string;
+  role?: UserRole | null;
+  onLogout?: () => void;
+  children: React.ReactNode;
+}
+
+export const LayoutShell: React.FC<LayoutShellProps> = ({
+  title,
+  subtitle,
+  navItems,
+  userName,
+  role,
+  onLogout,
+  children
+}) => {
+  return (
+    <div className="layout-shell">
+      <a href="#main-content" className="skip-link">
+        Skip to main content
+      </a>
+      <header className="layout-shell__header">
+        <div>
+          <h1 style={{ margin: 0 }}>{title}</h1>
+          {subtitle ? <p style={{ margin: 0, opacity: 0.85 }}>{subtitle}</p> : null}
+        </div>
+        <div aria-live="polite">
+          {userName ? (
+            <p style={{ margin: 0 }}>
+              Signed in as <strong>{userName}</strong>
+              {role ? (
+                <span className="badge badge--success" style={{ marginLeft: '0.5rem' }}>
+                  {role.toUpperCase()}
+                </span>
+              ) : null}
+            </p>
+          ) : (
+            <p style={{ margin: 0 }}>Not signed in</p>
+          )}
+          {onLogout ? (
+            <button type="button" onClick={onLogout} style={{ marginTop: '0.5rem' }}>
+              Log out
+            </button>
+          ) : null}
+        </div>
+      </header>
+      <div className="layout-shell__body">
+        <nav aria-label="Primary navigation" className="layout-shell__nav">
+          <ul>
+            {navItems.map((item) => (
+              <li key={item.to}>
+                <NavLink to={item.to} className={({ isActive }) => (isActive ? 'active' : undefined)}>
+                  <span style={{ display: 'block', fontWeight: 600 }}>{item.label}</span>
+                  {item.description ? (
+                    <span style={{ display: 'block', fontSize: '0.85rem', opacity: 0.7 }}>
+                      {item.description}
+                    </span>
+                  ) : null}
+                </NavLink>
+              </li>
+            ))}
+          </ul>
+        </nav>
+        <main id="main-content" className="layout-shell__main">
+          {children}
+        </main>
+      </div>
+    </div>
+  );
+};

--- a/frontend/src/layouts/ManagerLayout.tsx
+++ b/frontend/src/layouts/ManagerLayout.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { LayoutShell, type NavItem } from './LayoutShell';
+import type { AuthenticatedUser } from '../types';
+
+interface ManagerLayoutProps {
+  user: AuthenticatedUser;
+  onLogout: () => void;
+  children: React.ReactNode;
+}
+
+const navItems: NavItem[] = [
+  { label: 'Risk Dashboard', description: 'Risk posture at a glance', to: '/risks/dashboard' },
+  { label: 'Risk Matrix', description: 'Likelihood vs impact', to: '/risks/matrix' },
+  { label: 'Follow-up Tracker', description: 'Remediation accountability', to: '/risks/follow-up' },
+  { label: 'Reporting', description: 'Distribute insights', to: '/reports' }
+];
+
+export const ManagerLayout: React.FC<ManagerLayoutProps> = ({ user, onLogout, children }) => (
+  <LayoutShell
+    title="Risk Governance Studio"
+    subtitle="Manager overview"
+    navItems={navItems}
+    userName={user.name}
+    role={user.role}
+    onLogout={onLogout}
+  >
+    {children}
+  </LayoutShell>
+);

--- a/frontend/src/layouts/RoleBasedLayout.tsx
+++ b/frontend/src/layouts/RoleBasedLayout.tsx
@@ -1,0 +1,65 @@
+import React, { useCallback, useState } from 'react';
+import { useAuth } from '../context/AuthContext';
+import { AdminLayout } from './AdminLayout';
+import { AuditorLayout } from './AuditorLayout';
+import { ManagerLayout } from './ManagerLayout';
+import { LoginForm } from '../components/LoginForm';
+import type { UserRole } from '../types';
+
+interface RoleBasedLayoutProps {
+  children: React.ReactNode;
+}
+
+const resolveLayout = (role: UserRole) => {
+  switch (role) {
+    case 'admin':
+      return AdminLayout;
+    case 'auditor':
+      return AuditorLayout;
+    case 'manager':
+    default:
+      return ManagerLayout;
+  }
+};
+
+export const RoleBasedLayout: React.FC<RoleBasedLayoutProps> = ({ children }) => {
+  const { user, isLoading, login, logout } = useAuth();
+  const [loginError, setLoginError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleLogin = useCallback(async (credentials: { email: string; password: string }) => {
+    setIsSubmitting(true);
+    try {
+      await login(credentials);
+      setLoginError(null);
+    } catch (error) {
+      setLoginError(error instanceof Error ? error.message : 'Unable to sign in');
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [login]);
+
+  if (isLoading) {
+    return (
+      <div role="status" aria-live="polite" style={{ padding: '2rem' }}>
+        Loading workspace…
+      </div>
+    );
+  }
+
+  if (!user) {
+    return (
+      <div style={{ margin: '4rem auto', maxWidth: '680px', background: '#fff', padding: '3rem', borderRadius: '1rem', boxShadow: '0 40px 80px rgba(15, 23, 42, 0.1)' }}>
+        <h1>Sign in to the OpenIA assurance suite</h1>
+        <p>Authenticate with your enterprise credentials to access role-specific dashboards and tooling.</p>
+        <LoginForm onSubmit={handleLogin} isLoading={isSubmitting} errorMessage={loginError} />
+        <p style={{ fontSize: '0.85rem', color: '#4b5563', marginTop: '1.5rem' }}>
+          Need access? Contact your OpenIA administrator to be provisioned with the appropriate role.
+        </p>
+      </div>
+    );
+  }
+
+  const Layout = resolveLayout(user.role);
+  return <Layout user={user} onLogout={logout}>{children}</Layout>;
+};

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import ReactDOM from 'react-dom/client';
+import { BrowserRouter } from 'react-router-dom';
+import App from './App';
+import './styles.css';
+
+const rootElement = document.getElementById('root');
+
+if (!rootElement) {
+  throw new Error('Unable to find root element for React application');
+}
+
+ReactDOM.createRoot(rootElement).render(
+  <React.StrictMode>
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
+  </React.StrictMode>
+);

--- a/frontend/src/pages/AuditPlanning.tsx
+++ b/frontend/src/pages/AuditPlanning.tsx
@@ -1,0 +1,156 @@
+import React, { useState } from 'react';
+import { useAuditPlans } from '../api/audits';
+import type { AuditPlan } from '../types';
+
+const statusLabels: Record<AuditPlan['status'], string> = {
+  planned: 'Planned',
+  'in-progress': 'In progress',
+  complete: 'Complete'
+};
+
+export const AuditPlanning: React.FC = () => {
+  const { plans, createPlan, updatePlanStatus } = useAuditPlans();
+  const [title, setTitle] = useState('');
+  const [owner, setOwner] = useState('');
+  const [startDate, setStartDate] = useState('');
+  const [endDate, setEndDate] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    try {
+      await createPlan({ title, owner, startDate, endDate });
+      setTitle('');
+      setOwner('');
+      setStartDate('');
+      setEndDate('');
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to create plan');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleStatusChange = async (id: string, status: AuditPlan['status']) => {
+    try {
+      await updatePlanStatus(id, status);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to update plan status');
+    }
+  };
+
+  return (
+    <section>
+      <header style={{ marginBottom: '2rem' }}>
+        <h1>Audit planning</h1>
+        <p>Coordinate engagements, resources and timelines aligned to risk priorities.</p>
+      </header>
+      <div className="card" style={{ marginBottom: '2rem' }}>
+        <h2 style={{ marginTop: 0 }}>Add engagement</h2>
+        <form onSubmit={handleSubmit} className="form-grid" aria-describedby={error ? 'plan-error' : undefined}>
+          <div className="form-control">
+            <label htmlFor="plan-title">Engagement title</label>
+            <input
+              id="plan-title"
+              value={title}
+              onChange={(event) => setTitle(event.target.value)}
+              required
+            />
+          </div>
+          <div className="form-control">
+            <label htmlFor="plan-owner">Owner</label>
+            <input
+              id="plan-owner"
+              value={owner}
+              onChange={(event) => setOwner(event.target.value)}
+              required
+            />
+          </div>
+          <div className="form-control">
+            <label htmlFor="plan-start">Start date</label>
+            <input
+              id="plan-start"
+              type="date"
+              value={startDate}
+              onChange={(event) => setStartDate(event.target.value)}
+              required
+            />
+          </div>
+          <div className="form-control">
+            <label htmlFor="plan-end">End date</label>
+            <input
+              id="plan-end"
+              type="date"
+              value={endDate}
+              onChange={(event) => setEndDate(event.target.value)}
+              required
+            />
+          </div>
+          <div style={{ gridColumn: '1 / -1' }}>
+            {error ? (
+              <p id="plan-error" role="alert" style={{ color: '#b91c1c' }}>
+                {error}
+              </p>
+            ) : null}
+            <button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? 'Scheduling…' : 'Schedule engagement'}
+            </button>
+          </div>
+        </form>
+      </div>
+      <div className="card">
+        <h2 style={{ marginTop: 0 }}>Engagement roadmap</h2>
+        <table className="data-table">
+          <caption className="visually-hidden">Upcoming audit engagements</caption>
+          <thead>
+            <tr>
+              <th scope="col">Engagement</th>
+              <th scope="col">Owner</th>
+              <th scope="col">Schedule</th>
+              <th scope="col">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {plans.length === 0 ? (
+              <tr>
+                <td colSpan={4} style={{ textAlign: 'center', padding: '2rem' }}>
+                  No engagements scheduled yet.
+                </td>
+              </tr>
+            ) : (
+              plans.map((plan) => (
+                <tr key={plan.id}>
+                  <th scope="row">{plan.title}</th>
+                  <td>{plan.owner}</td>
+                  <td>
+                    <time dateTime={plan.startDate}>{plan.startDate}</time> –{' '}
+                    <time dateTime={plan.endDate}>{plan.endDate}</time>
+                  </td>
+                  <td>
+                    <label htmlFor={`status-${plan.id}`} className="visually-hidden">
+                      Update status for {plan.title}
+                    </label>
+                    <select
+                      id={`status-${plan.id}`}
+                      value={plan.status}
+                      onChange={(event) => handleStatusChange(plan.id, event.target.value as AuditPlan['status'])}
+                    >
+                      {Object.entries(statusLabels).map(([value, label]) => (
+                        <option key={value} value={value}>
+                          {label}
+                        </option>
+                      ))}
+                    </select>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+};

--- a/frontend/src/pages/FollowUpTracker.tsx
+++ b/frontend/src/pages/FollowUpTracker.tsx
@@ -1,0 +1,116 @@
+import React, { useMemo, useState } from 'react';
+import { useFollowUpItems } from '../api/risks';
+import type { FollowUpItem } from '../types';
+
+const statusOrder: FollowUpItem['status'][] = ['pending', 'in-progress', 'complete'];
+
+const statusLabel: Record<FollowUpItem['status'], string> = {
+  pending: 'Pending',
+  'in-progress': 'In progress',
+  complete: 'Complete'
+};
+
+export const FollowUpTracker: React.FC = () => {
+  const [riskId, setRiskId] = useState('');
+  const [statusFilter, setStatusFilter] = useState<FollowUpItem['status'] | 'all'>('all');
+  const { items } = useFollowUpItems(riskId || undefined);
+
+  const filteredItems = useMemo(() => {
+    if (statusFilter === 'all') return items;
+    return items.filter((item) => item.status === statusFilter);
+  }, [items, statusFilter]);
+
+  const completionRate = useMemo(() => {
+    if (!items.length) return 0;
+    const completed = items.filter((item) => item.status === 'complete').length;
+    return Math.round((completed / items.length) * 100);
+  }, [items]);
+
+  return (
+    <section>
+      <header style={{ marginBottom: '2rem' }}>
+        <h1>Follow-up tracker</h1>
+        <p>Monitor remediation activities to confirm risk treatments remain effective.</p>
+      </header>
+      <div className="card" style={{ marginBottom: '2rem' }}>
+        <h2 style={{ marginTop: 0 }}>Filters</h2>
+        <div className="form-grid">
+          <div className="form-control">
+            <label htmlFor="followup-risk">Risk identifier</label>
+            <input
+              id="followup-risk"
+              value={riskId}
+              onChange={(event) => setRiskId(event.target.value)}
+              placeholder="Enter risk ID"
+            />
+          </div>
+          <div className="form-control">
+            <label htmlFor="followup-status">Status</label>
+            <select
+              id="followup-status"
+              value={statusFilter}
+              onChange={(event) => setStatusFilter(event.target.value as FollowUpItem['status'] | 'all')}
+            >
+              <option value="all">All</option>
+              {statusOrder.map((status) => (
+                <option key={status} value={status}>
+                  {statusLabel[status]}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+      </div>
+      <article className="card" aria-label="Completion rate">
+        <h2>Remediation progress</h2>
+        <p style={{ marginTop: 0 }}>Overall completion rate {completionRate}%.</p>
+        <div style={{ height: '12px', background: '#e2e8f0', borderRadius: '999px', overflow: 'hidden' }}>
+          <div
+            style={{
+              width: `${completionRate}%`,
+              background: '#0ca678',
+              height: '100%'
+            }}
+            role="presentation"
+          />
+        </div>
+      </article>
+      <div className="card" style={{ marginTop: '2rem' }}>
+        <h2 style={{ marginTop: 0 }}>Action items</h2>
+        <table className="data-table">
+          <caption className="visually-hidden">Follow-up actions and due dates</caption>
+          <thead>
+            <tr>
+              <th scope="col">Risk</th>
+              <th scope="col">Action</th>
+              <th scope="col">Owner</th>
+              <th scope="col">Due date</th>
+              <th scope="col">Status</th>
+            </tr>
+          </thead>
+          <tbody>
+            {filteredItems.length === 0 ? (
+              <tr>
+                <td colSpan={5} style={{ textAlign: 'center', padding: '2rem' }}>
+                  No follow-up actions found.
+                </td>
+              </tr>
+            ) : (
+              filteredItems.map((item) => (
+                <tr key={item.id}>
+                  <th scope="row">{item.riskId}</th>
+                  <td>{item.action}</td>
+                  <td>{item.owner}</td>
+                  <td>
+                    <time dateTime={item.dueDate}>{item.dueDate}</time>
+                  </td>
+                  <td>{statusLabel[item.status]}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+};

--- a/frontend/src/pages/Reporting.tsx
+++ b/frontend/src/pages/Reporting.tsx
@@ -1,0 +1,128 @@
+import React, { useMemo, useState } from 'react';
+import { useReportDetails, useReports } from '../api/reports';
+import type { ReportSummary } from '../types';
+
+const statusLabel: Record<ReportSummary['status'], string> = {
+  draft: 'Draft',
+  issued: 'Issued'
+};
+
+export const Reporting: React.FC = () => {
+  const [status, setStatus] = useState<ReportSummary['status'] | 'all'>('all');
+  const [selectedReportId, setSelectedReportId] = useState<string | undefined>(undefined);
+  const { reports, generateReport } = useReports(status === 'all' ? undefined : { status });
+  const { report } = useReportDetails(selectedReportId);
+  const [message, setMessage] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const issuedCount = useMemo(() => reports.filter((item) => item.status === 'issued').length, [reports]);
+
+  const handleGenerate = async (id: string) => {
+    setMessage(null);
+    setError(null);
+    try {
+      const generated = await generateReport(id);
+      setMessage(`Report ${generated.title} generated successfully.`);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to generate report.');
+    }
+  };
+
+  return (
+    <section>
+      <header style={{ marginBottom: '2rem' }}>
+        <h1>Reporting</h1>
+        <p>Deliver timely updates to stakeholders with curated assurance insights.</p>
+      </header>
+      <div className="card-grid" style={{ marginBottom: '2rem' }}>
+        <article className="card">
+          <h2>Published reports</h2>
+          <p style={{ fontSize: '2.5rem', margin: 0 }}>{issuedCount}</p>
+          <p style={{ color: '#4b5563' }}>Reports issued in the current period</p>
+        </article>
+        <article className="card">
+          <h2>Active drafts</h2>
+          <p style={{ fontSize: '2.5rem', margin: 0 }}>{reports.length - issuedCount}</p>
+          <p style={{ color: '#4b5563' }}>Reports in progress awaiting approval</p>
+        </article>
+      </div>
+      <div className="card" style={{ marginBottom: '2rem' }}>
+        <h2 style={{ marginTop: 0 }}>Report library</h2>
+        <div className="form-control" style={{ maxWidth: '240px' }}>
+          <label htmlFor="report-status">Filter by status</label>
+          <select
+            id="report-status"
+            value={status}
+            onChange={(event) => setStatus(event.target.value as ReportSummary['status'] | 'all')}
+          >
+            <option value="all">All</option>
+            <option value="draft">Draft</option>
+            <option value="issued">Issued</option>
+          </select>
+        </div>
+        {message ? (
+          <p role="status" style={{ color: '#0ca678' }}>
+            {message}
+          </p>
+        ) : null}
+        {error ? (
+          <p role="alert" style={{ color: '#b91c1c' }}>
+            {error}
+          </p>
+        ) : null}
+        <table className="data-table" style={{ marginTop: '1rem' }}>
+          <caption className="visually-hidden">Reports and generation controls</caption>
+          <thead>
+            <tr>
+              <th scope="col">Title</th>
+              <th scope="col">Owner</th>
+              <th scope="col">Issued</th>
+              <th scope="col">Status</th>
+              <th scope="col">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {reports.length === 0 ? (
+              <tr>
+                <td colSpan={5} style={{ textAlign: 'center', padding: '2rem' }}>
+                  No reports match the selected filters.
+                </td>
+              </tr>
+            ) : (
+              reports.map((item) => (
+                <tr key={item.id}>
+                  <th scope="row">{item.title}</th>
+                  <td>{item.owner}</td>
+                  <td>
+                    <time dateTime={item.issuedDate}>{item.issuedDate}</time>
+                  </td>
+                  <td>{statusLabel[item.status]}</td>
+                  <td>
+                    <div style={{ display: 'flex', gap: '0.5rem', flexWrap: 'wrap' }}>
+                      <button type="button" onClick={() => setSelectedReportId(item.id)}>
+                        View
+                      </button>
+                      <button type="button" onClick={() => handleGenerate(item.id)}>
+                        Generate
+                      </button>
+                    </div>
+                  </td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+      {report ? (
+        <article className="card" aria-live="polite">
+          <h2 style={{ marginTop: 0 }}>{report.title}</h2>
+          <p>
+            Owned by <strong>{report.owner}</strong> — issued on{' '}
+            <time dateTime={report.issuedDate}>{report.issuedDate}</time>
+          </p>
+          <p>Status: {statusLabel[report.status]}</p>
+        </article>
+      ) : null}
+    </section>
+  );
+};

--- a/frontend/src/pages/RiskDashboard.tsx
+++ b/frontend/src/pages/RiskDashboard.tsx
@@ -1,0 +1,126 @@
+import React, { useMemo } from 'react';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  PointElement,
+  LineElement,
+  BarElement,
+  ArcElement,
+  Tooltip,
+  Legend
+} from 'chart.js';
+import { Line, Doughnut } from 'react-chartjs-2';
+import { useRiskSummary, useRisks } from '../api/risks';
+
+ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, BarElement, ArcElement, Tooltip, Legend);
+
+export const RiskDashboard: React.FC = () => {
+  const { summary, isLoading } = useRiskSummary();
+  const { risks } = useRisks({ status: 'open' });
+
+  const lineChartData = useMemo(() => {
+    const labels = summary?.trend.map((entry) => entry.month) ?? [];
+    return {
+      labels,
+      datasets: [
+        {
+          label: 'High',
+          data: summary?.trend.map((entry) => entry.high) ?? [],
+          borderColor: '#d12c2c',
+          backgroundColor: 'rgba(209, 44, 44, 0.1)',
+          tension: 0.3,
+          fill: true
+        },
+        {
+          label: 'Medium',
+          data: summary?.trend.map((entry) => entry.medium) ?? [],
+          borderColor: '#f08c00',
+          backgroundColor: 'rgba(240, 140, 0, 0.1)',
+          tension: 0.3,
+          fill: true
+        },
+        {
+          label: 'Low',
+          data: summary?.trend.map((entry) => entry.low) ?? [],
+          borderColor: '#0ca678',
+          backgroundColor: 'rgba(12, 166, 120, 0.1)',
+          tension: 0.3,
+          fill: true
+        }
+      ]
+    };
+  }, [summary]);
+
+  const doughnutData = useMemo(() => ({
+    labels: ['High', 'Medium', 'Low'],
+    datasets: [
+      {
+        data: [summary?.highRisks ?? 0, summary?.mediumRisks ?? 0, summary?.lowRisks ?? 0],
+        backgroundColor: ['#d12c2c', '#f08c00', '#0ca678'],
+        borderWidth: 0
+      }
+    ]
+  }), [summary]);
+
+  return (
+    <section aria-busy={isLoading} aria-live="polite">
+      <header style={{ marginBottom: '2rem' }}>
+        <h1>Risk dashboard</h1>
+        <p>Monitor the control environment, top exposures and mitigation progress in real time.</p>
+      </header>
+      <div className="card-grid" role="list">
+        <article className="card" role="listitem" aria-label="Total risks">
+          <h2>Total risks</h2>
+          <p style={{ fontSize: '2.5rem', margin: 0 }}>{summary?.totalRisks ?? '—'}</p>
+          <p style={{ color: '#4b5563' }}>Active inventory managed by assurance teams</p>
+        </article>
+        <article className="card" role="listitem" aria-label="High priority">
+          <h2>High priority</h2>
+          <p style={{ fontSize: '2.5rem', margin: 0 }}>{summary?.highRisks ?? '—'}</p>
+          <p style={{ color: '#4b5563' }}>Requires executive attention</p>
+        </article>
+        <article className="card" role="listitem" aria-label="Mitigation backlog">
+          <h2>Mitigation backlog</h2>
+          <p style={{ fontSize: '2.5rem', margin: 0 }}>{risks.length}</p>
+          <p style={{ color: '#4b5563' }}>Open items assigned to risk owners</p>
+        </article>
+      </div>
+      <div className="card-grid" style={{ marginTop: '2rem' }}>
+        <article className="chart-card" aria-label="Risk trend chart">
+          <h2 style={{ marginTop: 0 }}>Monthly exposure trend</h2>
+          <Line
+            data={lineChartData}
+            aria-label="Risk exposure trend chart"
+            role="img"
+            options={{
+              responsive: true,
+              maintainAspectRatio: false,
+              plugins: {
+                legend: { position: 'bottom' },
+                tooltip: { mode: 'index', intersect: false }
+              },
+              scales: {
+                y: { beginAtZero: true, title: { display: true, text: 'Number of risks' } },
+                x: { title: { display: true, text: 'Month' } }
+              }
+            }}
+            style={{ minHeight: '320px' }}
+          />
+        </article>
+        <article className="chart-card" aria-label="Risk distribution chart">
+          <h2 style={{ marginTop: 0 }}>Current severity mix</h2>
+          <Doughnut
+            data={doughnutData}
+            aria-label="Risk severity distribution"
+            role="img"
+            options={{ plugins: { legend: { position: 'bottom' } } }}
+          />
+          <p style={{ marginTop: '1rem', color: '#4b5563' }}>
+            Severity mix calculated from inherent and residual scores aggregated by category.
+          </p>
+        </article>
+      </div>
+    </section>
+  );
+};

--- a/frontend/src/pages/RiskIdentificationQuestionnaire.tsx
+++ b/frontend/src/pages/RiskIdentificationQuestionnaire.tsx
@@ -1,0 +1,171 @@
+import React, { useMemo, useState } from 'react';
+import { useRiskQuestionnaire } from '../api/risks';
+import type { QuestionnaireResponse } from '../types';
+
+const likertScale = [
+  { value: '1', label: 'Rare' },
+  { value: '2', label: 'Unlikely' },
+  { value: '3', label: 'Possible' },
+  { value: '4', label: 'Likely' },
+  { value: '5', label: 'Almost certain' }
+];
+
+const impactScale = [
+  { value: '1', label: 'Insignificant' },
+  { value: '2', label: 'Minor' },
+  { value: '3', label: 'Moderate' },
+  { value: '4', label: 'Major' },
+  { value: '5', label: 'Severe' }
+];
+
+export const RiskIdentificationQuestionnaire: React.FC = () => {
+  const { submit } = useRiskQuestionnaire();
+  const [owner, setOwner] = useState('');
+  const [riskCategory, setRiskCategory] = useState('');
+  const [likelihood, setLikelihood] = useState('3');
+  const [impact, setImpact] = useState('3');
+  const [description, setDescription] = useState('');
+  const [controls, setControls] = useState('');
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const inherentScore = useMemo(() => Number(likelihood) * Number(impact), [likelihood, impact]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const response: QuestionnaireResponse = {
+      responses: {
+        owner,
+        riskCategory,
+        likelihood,
+        impact,
+        description,
+        controls
+      }
+    };
+
+    try {
+      await submit(response);
+      setStatusMessage('Risk captured. Workflow has been initiated for assessment.');
+      setErrorMessage(null);
+      setDescription('');
+      setControls('');
+    } catch (error) {
+      setErrorMessage(error instanceof Error ? error.message : 'Unable to submit questionnaire.');
+      setStatusMessage(null);
+    }
+  };
+
+  return (
+    <section>
+      <header style={{ marginBottom: '2rem' }}>
+        <h1>Risk identification questionnaire</h1>
+        <p>Capture emerging risks with rich context to feed prioritisation and audit planning.</p>
+      </header>
+      <form onSubmit={handleSubmit} aria-describedby={errorMessage ? 'questionnaire-error' : undefined}>
+        <div className="form-grid">
+          <div className="form-control">
+            <label htmlFor="owner">Risk owner</label>
+            <input
+              id="owner"
+              name="owner"
+              value={owner}
+              onChange={(event) => setOwner(event.target.value)}
+              required
+            />
+          </div>
+          <div className="form-control">
+            <label htmlFor="riskCategory">Risk category</label>
+            <select
+              id="riskCategory"
+              name="riskCategory"
+              value={riskCategory}
+              onChange={(event) => setRiskCategory(event.target.value)}
+              required
+            >
+              <option value="" disabled>
+                Select a category
+              </option>
+              <option value="strategic">Strategic</option>
+              <option value="financial">Financial</option>
+              <option value="compliance">Compliance</option>
+              <option value="operational">Operational</option>
+              <option value="technology">Technology</option>
+            </select>
+          </div>
+          <div className="form-control">
+            <label htmlFor="likelihood">Likelihood</label>
+            <select
+              id="likelihood"
+              name="likelihood"
+              value={likelihood}
+              onChange={(event) => setLikelihood(event.target.value)}
+            >
+              {likertScale.map((item) => (
+                <option key={item.value} value={item.value}>
+                  {item.label}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div className="form-control">
+            <label htmlFor="impact">Impact</label>
+            <select
+              id="impact"
+              name="impact"
+              value={impact}
+              onChange={(event) => setImpact(event.target.value)}
+            >
+              {impactScale.map((item) => (
+                <option key={item.value} value={item.value}>
+                  {item.label}
+                </option>
+              ))}
+            </select>
+          </div>
+        </div>
+        <div className="form-grid" style={{ marginTop: '1.5rem' }}>
+          <div className="form-control">
+            <label htmlFor="description">Risk description</label>
+            <textarea
+              id="description"
+              name="description"
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              placeholder="Describe the scenario, drivers and potential outcomes"
+              required
+            />
+          </div>
+          <div className="form-control">
+            <label htmlFor="controls">Existing controls</label>
+            <textarea
+              id="controls"
+              name="controls"
+              value={controls}
+              onChange={(event) => setControls(event.target.value)}
+              placeholder="Summarise preventive and detective measures currently in place"
+            />
+          </div>
+        </div>
+        <aside style={{ marginTop: '1.5rem' }} aria-live="polite">
+          <p>
+            Estimated inherent score: <strong>{inherentScore}</strong> (likelihood {likelihood} × impact {impact}).
+          </p>
+        </aside>
+        {errorMessage ? (
+          <p id="questionnaire-error" role="alert" style={{ color: '#b91c1c' }}>
+            {errorMessage}
+          </p>
+        ) : null}
+        {statusMessage ? (
+          <p role="status" style={{ color: '#0ca678' }}>
+            {statusMessage}
+          </p>
+        ) : null}
+        <button type="submit" style={{ marginTop: '1.5rem' }}>
+          Submit risk for review
+        </button>
+      </form>
+    </section>
+  );
+};

--- a/frontend/src/pages/RiskMatrix.tsx
+++ b/frontend/src/pages/RiskMatrix.tsx
@@ -1,0 +1,115 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import * as d3 from 'd3';
+import { useRisks } from '../api/risks';
+
+const scaleLabels = ['Rare', 'Unlikely', 'Possible', 'Likely', 'Almost certain'];
+const impactLabels = ['Insignificant', 'Minor', 'Moderate', 'Major', 'Severe'];
+
+const toIndex = (value: number) => Math.max(0, Math.min(4, Math.round(value) - 1));
+
+export const RiskMatrix: React.FC = () => {
+  const { risks } = useRisks();
+  const svgRef = useRef<SVGSVGElement | null>(null);
+
+  const matrix = useMemo(() => {
+    const base = Array.from({ length: 5 }, () => Array(5).fill(0));
+    for (const risk of risks) {
+      const likelihoodIndex = toIndex(risk.inherentRisk);
+      const impactIndex = toIndex(risk.residualRisk);
+      base[4 - impactIndex][likelihoodIndex] += 1;
+    }
+    return base;
+  }, [risks]);
+
+  useEffect(() => {
+    const svg = d3.select(svgRef.current);
+    const size = 400;
+    const cellSize = size / 5;
+
+    svg.attr('viewBox', `0 0 ${size + 120} ${size + 60}`);
+    svg.selectAll('*').remove();
+
+    const colorScale = d3
+      .scaleSequential<number>()
+      .domain([0, d3.max(matrix.flat()) || 1])
+      .interpolator(d3.interpolateYlOrRd);
+
+    const group = svg.append('g').attr('transform', 'translate(100, 20)');
+
+    matrix.forEach((row, rowIndex) => {
+      row.forEach((value, columnIndex) => {
+        const x = columnIndex * cellSize;
+        const y = rowIndex * cellSize;
+        group
+          .append('rect')
+          .attr('x', x)
+          .attr('y', y)
+          .attr('width', cellSize - 2)
+          .attr('height', cellSize - 2)
+          .attr('rx', 8)
+          .attr('ry', 8)
+          .attr('fill', colorScale(value));
+
+        group
+          .append('text')
+          .attr('x', x + cellSize / 2)
+          .attr('y', y + cellSize / 2)
+          .attr('text-anchor', 'middle')
+          .attr('dy', '0.35em')
+          .attr('fill', value > (d3.max(matrix.flat()) || 1) / 2 ? '#fff' : '#1f2933')
+          .style('font-size', '0.85rem')
+          .text(value ? value.toString() : '');
+      });
+    });
+
+    scaleLabels.forEach((label, index) => {
+      svg
+        .append('text')
+        .attr('x', 110 + index * cellSize)
+        .attr('y', size + 40)
+        .attr('text-anchor', 'middle')
+        .style('font-size', '0.85rem')
+        .text(label);
+    });
+
+    impactLabels.forEach((label, index) => {
+      svg
+        .append('text')
+        .attr('x', 20)
+        .attr('y', 40 + index * cellSize)
+        .attr('text-anchor', 'end')
+        .style('font-size', '0.85rem')
+        .text(label);
+    });
+
+    svg
+      .append('text')
+      .attr('x', size / 2 + 100)
+      .attr('y', size + 55)
+      .attr('text-anchor', 'middle')
+      .style('font-weight', '600')
+      .text('Likelihood');
+
+    svg
+      .append('text')
+      .attr('transform', `translate(20, ${size / 2 + 20}) rotate(-90)`)
+      .attr('text-anchor', 'middle')
+      .style('font-weight', '600')
+      .text('Impact');
+  }, [matrix]);
+
+  return (
+    <section>
+      <header style={{ marginBottom: '2rem' }}>
+        <h1>Risk heat matrix</h1>
+        <p>Visualise the distribution of inherent and residual risk to prioritise assurance activities.</p>
+      </header>
+      <div role="img" aria-label="Risk heat map showing distribution of risks by likelihood and impact" style={{ background: '#fff', padding: '1rem', borderRadius: '1rem', boxShadow: '0 15px 40px rgba(15, 23, 42, 0.08)' }}>
+        <svg ref={svgRef} width="100%" height="100%" aria-hidden="true" />
+      </div>
+      <p style={{ marginTop: '1rem', color: '#4b5563' }}>
+        Each tile highlights the number of risks falling within the corresponding likelihood and impact intersection.
+      </p>
+    </section>
+  );
+};

--- a/frontend/src/pages/Timesheets.tsx
+++ b/frontend/src/pages/Timesheets.tsx
@@ -1,0 +1,189 @@
+import React, { useMemo, useState } from 'react';
+import {
+  Chart as ChartJS,
+  CategoryScale,
+  LinearScale,
+  BarElement,
+  Tooltip,
+  Legend
+} from 'chart.js';
+import { Bar } from 'react-chartjs-2';
+import { useTimesheets } from '../api/audits';
+import type { TimesheetEntry } from '../types';
+
+ChartJS.register(CategoryScale, LinearScale, BarElement, Tooltip, Legend);
+
+export const Timesheets: React.FC = () => {
+  const { entries, submitEntry } = useTimesheets();
+  const [auditor, setAuditor] = useState('');
+  const [date, setDate] = useState('');
+  const [hours, setHours] = useState('');
+  const [engagement, setEngagement] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const totalHours = useMemo(() => entries.reduce((sum, item) => sum + item.hours, 0), [entries]);
+
+  const chartData = useMemo(() => {
+    const grouped = entries.reduce<Record<string, number>>((acc, entry) => {
+      acc[entry.engagement] = (acc[entry.engagement] ?? 0) + entry.hours;
+      return acc;
+    }, {});
+
+    return {
+      labels: Object.keys(grouped),
+      datasets: [
+        {
+          label: 'Hours recorded',
+          data: Object.values(grouped),
+          backgroundColor: 'rgba(11, 114, 133, 0.6)',
+          borderRadius: 12
+        }
+      ]
+    };
+  }, [entries]);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setIsSubmitting(true);
+    const payload: Partial<TimesheetEntry> = {
+      auditor,
+      date,
+      hours: Number(hours),
+      engagement
+    };
+
+    try {
+      await submitEntry(payload);
+      setAuditor('');
+      setDate('');
+      setHours('');
+      setEngagement('');
+      setError(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unable to submit timesheet');
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <section>
+      <header style={{ marginBottom: '2rem' }}>
+        <h1>Timesheets</h1>
+        <p>Track utilisation by engagement to optimise coverage and budgets.</p>
+      </header>
+      <div className="card" style={{ marginBottom: '2rem' }}>
+        <h2 style={{ marginTop: 0 }}>Log effort</h2>
+        <form onSubmit={handleSubmit} className="form-grid" aria-describedby={error ? 'timesheet-error' : undefined}>
+          <div className="form-control">
+            <label htmlFor="timesheet-auditor">Auditor</label>
+            <input
+              id="timesheet-auditor"
+              value={auditor}
+              onChange={(event) => setAuditor(event.target.value)}
+              required
+            />
+          </div>
+          <div className="form-control">
+            <label htmlFor="timesheet-date">Date</label>
+            <input
+              id="timesheet-date"
+              type="date"
+              value={date}
+              onChange={(event) => setDate(event.target.value)}
+              required
+            />
+          </div>
+          <div className="form-control">
+            <label htmlFor="timesheet-hours">Hours</label>
+            <input
+              id="timesheet-hours"
+              type="number"
+              min={0}
+              step="0.25"
+              value={hours}
+              onChange={(event) => setHours(event.target.value)}
+              required
+            />
+          </div>
+          <div className="form-control">
+            <label htmlFor="timesheet-engagement">Engagement</label>
+            <input
+              id="timesheet-engagement"
+              value={engagement}
+              onChange={(event) => setEngagement(event.target.value)}
+              required
+            />
+          </div>
+          <div style={{ gridColumn: '1 / -1' }}>
+            {error ? (
+              <p id="timesheet-error" role="alert" style={{ color: '#b91c1c' }}>
+                {error}
+              </p>
+            ) : null}
+            <button type="submit" disabled={isSubmitting}>
+              {isSubmitting ? 'Saving…' : 'Save entry'}
+            </button>
+          </div>
+        </form>
+      </div>
+      <div className="card-grid">
+        <article className="card" aria-label="Total hours">
+          <h2>Total hours this period</h2>
+          <p style={{ fontSize: '2.5rem', margin: 0 }}>{totalHours.toFixed(1)}</p>
+          <p style={{ color: '#4b5563' }}>Inclusive of all logged engagements</p>
+        </article>
+        <article className="chart-card" aria-label="Hours by engagement chart">
+          <h2 style={{ marginTop: 0 }}>Hours by engagement</h2>
+          <Bar
+            data={chartData}
+            options={{
+              responsive: true,
+              plugins: { legend: { display: false } },
+              scales: {
+                y: { beginAtZero: true, title: { display: true, text: 'Hours' } }
+              }
+            }}
+            aria-label="Bar chart of hours by engagement"
+            role="img"
+          />
+        </article>
+      </div>
+      <div className="card" style={{ marginTop: '2rem' }}>
+        <h2 style={{ marginTop: 0 }}>Detailed entries</h2>
+        <table className="data-table">
+          <caption className="visually-hidden">Timesheet entries</caption>
+          <thead>
+            <tr>
+              <th scope="col">Auditor</th>
+              <th scope="col">Engagement</th>
+              <th scope="col">Date</th>
+              <th scope="col">Hours</th>
+            </tr>
+          </thead>
+          <tbody>
+            {entries.length === 0 ? (
+              <tr>
+                <td colSpan={4} style={{ textAlign: 'center', padding: '2rem' }}>
+                  No entries recorded.
+                </td>
+              </tr>
+            ) : (
+              entries.map((entry) => (
+                <tr key={entry.id}>
+                  <th scope="row">{entry.auditor}</th>
+                  <td>{entry.engagement}</td>
+                  <td>
+                    <time dateTime={entry.date}>{entry.date}</time>
+                  </td>
+                  <td>{entry.hours.toFixed(1)}</td>
+                </tr>
+              ))
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+};

--- a/frontend/src/pages/WorkingPapers.tsx
+++ b/frontend/src/pages/WorkingPapers.tsx
@@ -1,0 +1,111 @@
+import React, { useMemo, useState } from 'react';
+import { useWorkingPapers } from '../api/audits';
+import type { WorkingPaper } from '../types';
+
+const statusToBadge: Record<WorkingPaper['status'], string> = {
+  draft: 'badge--warning',
+  review: 'badge--danger',
+  approved: 'badge--success'
+};
+
+export const WorkingPapers: React.FC = () => {
+  const [auditId, setAuditId] = useState('');
+  const { papers, updateStatus } = useWorkingPapers(auditId || undefined);
+  const [selectedPaper, setSelectedPaper] = useState<WorkingPaper | null>(null);
+
+  const lastUpdated = useMemo(() => {
+    if (!papers.length) return null;
+    return papers.reduce((latest, paper) => (paper.updatedAt > latest.updatedAt ? paper : latest));
+  }, [papers]);
+
+  const handleStatusChange = async (paper: WorkingPaper, status: WorkingPaper['status']) => {
+    await updateStatus(paper.id, status);
+  };
+
+  return (
+    <section>
+      <header style={{ marginBottom: '2rem' }}>
+        <h1>Working papers</h1>
+        <p>Maintain fieldwork evidence, review notes and approvals.</p>
+      </header>
+      <div className="card" style={{ marginBottom: '2rem' }}>
+        <h2 style={{ marginTop: 0 }}>Filter by engagement</h2>
+        <div className="form-control" style={{ maxWidth: '320px' }}>
+          <label htmlFor="audit-filter">Audit identifier</label>
+          <input
+            id="audit-filter"
+            value={auditId}
+            onChange={(event) => setAuditId(event.target.value)}
+            placeholder="Enter engagement ID"
+          />
+        </div>
+        {lastUpdated ? (
+          <p style={{ marginTop: '1rem', color: '#4b5563' }}>
+            Latest update: <strong>{lastUpdated.name}</strong> on{' '}
+            <time dateTime={lastUpdated.updatedAt}>{lastUpdated.updatedAt}</time>
+          </p>
+        ) : null}
+      </div>
+      <div className="card-grid">
+        {papers.map((paper) => (
+          <article className="card" key={paper.id}>
+            <h2 style={{ marginTop: 0 }}>{paper.name}</h2>
+            <p style={{ color: '#4b5563' }}>Owner: {paper.owner}</p>
+            <p>
+              <span className={`badge ${statusToBadge[paper.status]}`}>{paper.status.toUpperCase()}</span>
+            </p>
+            <p style={{ color: '#4b5563' }}>
+              Updated <time dateTime={paper.updatedAt}>{paper.updatedAt}</time>
+            </p>
+            <button type="button" onClick={() => setSelectedPaper(paper)}>
+              View details
+            </button>
+            <div style={{ marginTop: '1rem' }}>
+              <label htmlFor={`paper-status-${paper.id}`} className="visually-hidden">
+                Update status for {paper.name}
+              </label>
+              <select
+                id={`paper-status-${paper.id}`}
+                value={paper.status}
+                onChange={(event) => handleStatusChange(paper, event.target.value as WorkingPaper['status'])}
+              >
+                <option value="draft">Draft</option>
+                <option value="review">In review</option>
+                <option value="approved">Approved</option>
+              </select>
+            </div>
+          </article>
+        ))}
+      </div>
+      {papers.length === 0 ? (
+        <p>No working papers found for the selected engagement.</p>
+      ) : null}
+      {selectedPaper ? (
+        <div role="dialog" aria-modal="true" aria-labelledby="paper-dialog-title" style={{ marginTop: '2rem', background: '#fff', padding: '2rem', borderRadius: '1rem', boxShadow: '0 20px 40px rgba(15, 23, 42, 0.2)' }}>
+          <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+            <h2 id="paper-dialog-title" style={{ margin: 0 }}>{selectedPaper.name}</h2>
+            <button type="button" onClick={() => setSelectedPaper(null)}>
+              Close
+            </button>
+          </div>
+          <dl>
+            <div>
+              <dt>Owner</dt>
+              <dd>{selectedPaper.owner}</dd>
+            </div>
+            <div>
+              <dt>Status</dt>
+              <dd>{selectedPaper.status}</dd>
+            </div>
+            <div>
+              <dt>Last updated</dt>
+              <dd>
+                <time dateTime={selectedPaper.updatedAt}>{selectedPaper.updatedAt}</time>
+              </dd>
+            </div>
+          </dl>
+        </div>
+      ) : null}
+    </section>
+  );
+};

--- a/frontend/src/setupTests.ts
+++ b/frontend/src/setupTests.ts
@@ -1,0 +1,50 @@
+import '@testing-library/jest-dom';
+import 'whatwg-fetch';
+
+class ResizeObserverMock {
+  observe() {
+    return undefined;
+  }
+  unobserve() {
+    return undefined;
+  }
+  disconnect() {
+    return undefined;
+  }
+}
+
+if (typeof window !== 'undefined' && !window.ResizeObserver) {
+  window.ResizeObserver = ResizeObserverMock as unknown as typeof ResizeObserver;
+}
+
+Object.defineProperty(window.HTMLCanvasElement.prototype, 'getContext', {
+  value: () => ({
+    fillRect: () => undefined,
+    clearRect: () => undefined,
+    getImageData: () => ({ data: new Uint8ClampedArray() }),
+    putImageData: () => undefined,
+    createImageData: () => ({ data: new Uint8ClampedArray() }),
+    setTransform: () => undefined,
+    drawImage: () => undefined,
+    save: () => undefined,
+    fillText: () => undefined,
+    restore: () => undefined,
+    beginPath: () => undefined,
+    closePath: () => undefined,
+    moveTo: () => undefined,
+    lineTo: () => undefined,
+    clip: () => undefined,
+    arc: () => undefined,
+    quadraticCurveTo: () => undefined,
+    createLinearGradient: () => ({ addColorStop: () => undefined }),
+    createPattern: () => undefined,
+    createRadialGradient: () => ({ addColorStop: () => undefined }),
+    rect: () => undefined,
+    rotate: () => undefined,
+    scale: () => undefined,
+    translate: () => undefined,
+    transform: () => undefined,
+    setLineDash: () => undefined,
+    getLineDash: () => []
+  })
+});

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -1,0 +1,258 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  line-height: 1.5;
+  font-weight: 400;
+  background-color: #f5f5f5;
+  color: #222;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background-color: inherit;
+}
+
+a {
+  color: #0b7285;
+  text-decoration: none;
+}
+
+main {
+  padding: 1rem;
+}
+
+button, input, select, textarea {
+  font: inherit;
+}
+
+.visually-hidden {
+  position: absolute;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  width: 1px;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.skip-link {
+  position: absolute;
+  left: -999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+  z-index: -999;
+  color: white;
+  background: #0b7285;
+  padding: 0.5rem 1rem;
+  border-radius: 0 0 0.5rem 0;
+}
+
+.skip-link:focus {
+  left: 0;
+  top: 0;
+  width: auto;
+  height: auto;
+  overflow: visible;
+  z-index: 999;
+}
+
+.layout-shell {
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.layout-shell__header {
+  background: linear-gradient(135deg, #0b7285, #1f6f8b);
+  color: #fff;
+  padding: 1rem 1.5rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.layout-shell__body {
+  display: flex;
+  flex: 1;
+  background-color: #f1f3f5;
+}
+
+.layout-shell__nav {
+  width: 260px;
+  background: #fff;
+  border-right: 1px solid #dee2e6;
+  padding: 1rem 0.5rem;
+}
+
+.layout-shell__nav ul {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.layout-shell__nav a {
+  display: block;
+  padding: 0.75rem 1rem;
+  margin: 0.25rem 0.5rem;
+  border-radius: 0.5rem;
+  color: #1f2933;
+  font-weight: 500;
+}
+
+.layout-shell__nav a:hover,
+.layout-shell__nav a:focus {
+  background-color: rgba(11, 114, 133, 0.1);
+  outline: none;
+}
+
+.layout-shell__nav a.active {
+  background-color: #0b7285;
+  color: #fff;
+}
+
+.layout-shell__main {
+  flex: 1;
+  padding: 2rem;
+  background: #fff;
+  overflow-y: auto;
+}
+
+.card-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.card {
+  background: #fff;
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  box-shadow: 0 10px 30px rgba(31, 105, 129, 0.1);
+}
+
+.card h2 {
+  margin-top: 0;
+  font-size: 1.25rem;
+}
+
+.form-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.form-control {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.form-control label {
+  font-weight: 600;
+}
+
+.form-control input,
+.form-control select,
+.form-control textarea {
+  padding: 0.5rem 0.75rem;
+  border: 1px solid #ced4da;
+  border-radius: 0.5rem;
+}
+
+.form-control textarea {
+  min-height: 120px;
+}
+
+.data-table {
+  width: 100%;
+  border-collapse: collapse;
+  margin-top: 1rem;
+  background: #fff;
+  border-radius: 0.75rem;
+  overflow: hidden;
+}
+
+.data-table th,
+.data-table td {
+  padding: 0.75rem 1rem;
+  border-bottom: 1px solid #dee2e6;
+  text-align: left;
+}
+
+.data-table tbody tr:nth-child(even) {
+  background-color: rgba(31, 105, 129, 0.05);
+}
+
+.badge {
+  display: inline-block;
+  padding: 0.25rem 0.5rem;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.badge--success {
+  background: rgba(34, 197, 94, 0.15);
+  color: #15803d;
+}
+
+.badge--warning {
+  background: rgba(251, 191, 36, 0.15);
+  color: #92400e;
+}
+
+.badge--danger {
+  background: rgba(248, 113, 113, 0.15);
+  color: #b91c1c;
+}
+
+.chart-card {
+  background: #fff;
+  padding: 1rem;
+  border-radius: 0.75rem;
+  box-shadow: 0 10px 30px rgba(31, 105, 129, 0.08);
+}
+
+.layout-shell__header button {
+  background: rgba(255, 255, 255, 0.15);
+  color: inherit;
+  border: 1px solid rgba(255, 255, 255, 0.3);
+  padding: 0.5rem 1rem;
+  border-radius: 999px;
+  cursor: pointer;
+}
+
+.layout-shell__header button:hover,
+.layout-shell__header button:focus {
+  background: rgba(255, 255, 255, 0.35);
+}
+
+@media (max-width: 900px) {
+  .layout-shell__body {
+    flex-direction: column;
+  }
+
+  .layout-shell__nav {
+    width: 100%;
+    display: flex;
+    overflow-x: auto;
+  }
+
+  .layout-shell__nav ul {
+    display: flex;
+    width: 100%;
+    gap: 0.5rem;
+  }
+
+  .layout-shell__nav li {
+    flex: 1;
+  }
+
+  .layout-shell__nav a {
+    margin: 0.25rem;
+    text-align: center;
+  }
+}

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,0 +1,73 @@
+export type UserRole = 'admin' | 'auditor' | 'manager';
+
+export interface AuthenticatedUser {
+  id: string;
+  name: string;
+  email: string;
+  role: UserRole;
+}
+
+export interface Risk {
+  id: string;
+  title: string;
+  category: string;
+  inherentRisk: number;
+  residualRisk: number;
+  owner: string;
+  status: 'open' | 'mitigated' | 'closed';
+}
+
+export interface RiskSummary {
+  totalRisks: number;
+  highRisks: number;
+  mediumRisks: number;
+  lowRisks: number;
+  trend: Array<{ month: string; high: number; medium: number; low: number }>;
+}
+
+export interface QuestionnaireResponse {
+  riskId?: string;
+  responses: Record<string, string>;
+}
+
+export interface AuditPlan {
+  id: string;
+  title: string;
+  owner: string;
+  startDate: string;
+  endDate: string;
+  status: 'planned' | 'in-progress' | 'complete';
+}
+
+export interface TimesheetEntry {
+  id: string;
+  auditor: string;
+  date: string;
+  hours: number;
+  engagement: string;
+}
+
+export interface WorkingPaper {
+  id: string;
+  name: string;
+  owner: string;
+  status: 'draft' | 'review' | 'approved';
+  updatedAt: string;
+}
+
+export interface FollowUpItem {
+  id: string;
+  riskId: string;
+  action: string;
+  owner: string;
+  dueDate: string;
+  status: 'pending' | 'in-progress' | 'complete';
+}
+
+export interface ReportSummary {
+  id: string;
+  title: string;
+  issuedDate: string;
+  owner: string;
+  status: 'draft' | 'issued';
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,23 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "useDefineForClassFields": true,
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "forceConsistentCasingInFileNames": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "jsx": "react-jsx",
+    "baseUrl": "./src",
+    "types": ["jest", "node"]
+  },
+  "include": ["src"],
+  "references": [{ "path": "./tsconfig.node.json" }]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "allowSyntheticDefaultImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vite';
+import react from '@vitejs/plugin-react';
+
+export default defineConfig({
+  plugins: [react()],
+  server: {
+    port: 5173
+  }
+});


### PR DESCRIPTION
## Summary
- scaffold a Vite-powered React + TypeScript frontend with routing, role-based layouts, and shared styling
- build risk, audit, and reporting pages that include Chart.js and D3 visualizations alongside accessible questionnaire and tracker forms
- implement API hooks for auth, risks, audits, and reports with JWT persistence plus Jest and RTL coverage for login and dashboard flows

## Testing
- `npm install` *(fails: 403 Forbidden fetching @testing-library/jest-dom)*

------
https://chatgpt.com/codex/tasks/task_e_68cdbb8ea48483289bde4ff935094c60