### PR TITLE
Add governance backend services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,18 @@
 # OpenIA
+
+## Backend services
+
+The `backend/` folder contains an Express-style implementation of the Governance, Risk and Compliance (GRC) services, including:
+
+- Auth, Risk, Audit, and Report APIs with OpenAPI documentation exposed at `/openapi.json`.
+- Domain models with validation, PostgreSQL-style repositories, Redis caching, and Kafka/RabbitMQ-inspired event publishing stubs.
+- Business services such as `RiskEngine`, `AuditEngine`, `Feedback`, `CoreIntegration`, `COSO`, and `IIA`.
+
+### Development
+
+```bash
+cd backend
+npm test
+```
+
+Run `npm start` to launch the API server (defaults to port `3000`).

--- a/backend/apis/audit.js
+++ b/backend/apis/audit.js
@@ -1,0 +1,60 @@
+const express = require('../framework/express');
+const { AuditEngagementSchema } = require('../domain/auditEngagement');
+const { FindingSchema } = require('../domain/finding');
+
+function createAuditRouter({ auditEngine }) {
+  const router = express.Router();
+
+  /**
+   * @openapi
+   * /audits:
+   *   get:
+   *     summary: List audits
+   */
+  router.get('/', async (req, res) => {
+    try {
+      const audits = await auditEngine.listAudits();
+      res.json({ data: audits });
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  /**
+   * @openapi
+   * /audits:
+   *   post:
+   *     summary: Plan an audit
+   */
+  router.post('/', async (req, res) => {
+    try {
+      const payload = AuditEngagementSchema.parse(req.body);
+      const audit = await auditEngine.planAudit(payload);
+      res.status(201).json({ data: audit });
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+
+  /**
+   * @openapi
+   * /audits/{id}/findings:
+   *   post:
+   *     summary: Attach a finding to an audit
+   */
+  router.post('/:id/findings', async (req, res) => {
+    try {
+      const { id } = req.params;
+      const payload = FindingSchema.parse(req.body);
+      const audit = await auditEngine.addFinding(id, payload);
+      res.json({ data: audit });
+    } catch (err) {
+      const status = err.message === 'Audit not found' ? 404 : 400;
+      res.status(status).json({ error: err.message });
+    }
+  });
+
+  return router;
+}
+
+module.exports = createAuditRouter;

--- a/backend/apis/auth.js
+++ b/backend/apis/auth.js
@@ -1,0 +1,36 @@
+const express = require('../framework/express');
+
+function createAuthRouter({ eventBus }) {
+  const router = express.Router();
+
+  /**
+   * @openapi
+   * /auth/health:
+   *   get:
+   *     summary: Health check for the auth service
+   */
+  router.get('/health', (req, res) => {
+    res.json({ status: 'ok' });
+  });
+
+  /**
+   * @openapi
+   * /auth/login:
+   *   post:
+   *     summary: Authenticate a user and return a token
+   */
+  router.post('/login', (req, res) => {
+    const { username, password } = req.body || {};
+    if (!username || !password) {
+      res.status(400).json({ error: 'username and password are required' });
+      return;
+    }
+    const token = Buffer.from(`${username}:${Date.now()}`).toString('base64');
+    eventBus.publish('auth_login', { username });
+    res.json({ token, expiresIn: 3600 });
+  });
+
+  return router;
+}
+
+module.exports = createAuthRouter;

--- a/backend/apis/report.js
+++ b/backend/apis/report.js
@@ -1,0 +1,72 @@
+const express = require('../framework/express');
+
+function calculateAverage(numbers) {
+  if (!numbers.length) {
+    return 0;
+  }
+  const total = numbers.reduce((sum, value) => sum + value, 0);
+  return Math.round((total / numbers.length) * 100) / 100;
+}
+
+function createReportRouter({ riskEngine, auditEngine, feedbackService, coso }) {
+  const router = express.Router();
+
+  /**
+   * @openapi
+   * /reports:
+   *   get:
+   *     summary: Governance analytics summary
+   */
+  router.get('/', async (req, res) => {
+    try {
+      const risks = await riskEngine.listRisks();
+      const audits = await auditEngine.listAudits();
+      const residualScores = risks.map((risk) => coso.calculateResidualScore(risk));
+      const readinessScores = audits.map((audit) => audit.readinessScore || 0);
+
+      const data = {
+        totalRisks: risks.length,
+        totalAudits: audits.length,
+        averageResidualScore: calculateAverage(residualScores),
+        averageAuditReadiness: calculateAverage(readinessScores),
+        openRisks: risks.filter((risk) => risk.status === 'open').length,
+        completedAudits: audits.filter((audit) => audit.status === 'completed').length,
+        feedback: feedbackService.getFeedback('report') || [],
+      };
+
+      res.json({ data });
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  /**
+   * @openapi
+   * /reports/feedback:
+   *   post:
+   *     summary: Submit feedback on reports
+   */
+  router.post('/feedback', (req, res) => {
+    try {
+      const entry = feedbackService.captureFeedback('report', req.body);
+      res.status(201).json({ data: entry });
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+
+  /**
+   * @openapi
+   * /reports/feedback:
+   *   get:
+   *     summary: List report feedback entries
+   */
+  router.get('/feedback', (req, res) => {
+    const entries = feedbackService.getFeedback('report');
+    res.json({ data: entries });
+  });
+
+  return router;
+}
+
+module.exports = createReportRouter;

--- a/backend/apis/risk.js
+++ b/backend/apis/risk.js
@@ -1,0 +1,62 @@
+const express = require('../framework/express');
+const { RiskSchema } = require('../domain/risk');
+
+function createRiskRouter({ riskEngine }) {
+  const router = express.Router();
+
+  /**
+   * @openapi
+   * /risks:
+   *   get:
+   *     summary: List risks
+   *     responses:
+   *       200:
+   *         description: A list of risks
+   */
+  router.get('/', async (req, res) => {
+    try {
+      const risks = await riskEngine.listRisks();
+      res.json({ data: risks });
+    } catch (err) {
+      res.status(500).json({ error: err.message });
+    }
+  });
+
+  /**
+   * @openapi
+   * /risks:
+   *   post:
+   *     summary: Create a risk
+   */
+  router.post('/', async (req, res) => {
+    try {
+      const payload = RiskSchema.parse(req.body);
+      const risk = await riskEngine.createRisk(payload);
+      res.status(201).json({ data: risk });
+    } catch (err) {
+      res.status(400).json({ error: err.message });
+    }
+  });
+
+  /**
+   * @openapi
+   * /risks/{id}:
+   *   put:
+   *     summary: Update a risk
+   */
+  router.put('/:id', async (req, res) => {
+    try {
+      const { id } = req.params;
+      const payload = { ...req.body, id };
+      const risk = await riskEngine.updateRisk(id, payload);
+      res.json({ data: risk });
+    } catch (err) {
+      const status = err.message === 'Risk not found' ? 404 : 400;
+      res.status(status).json({ error: err.message });
+    }
+  });
+
+  return router;
+}
+
+module.exports = createRiskRouter;

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,0 +1,88 @@
+const express = require('./framework/express');
+const EventBus = require('./mq/eventBus');
+const RedisCache = require('./cache/redisCache');
+const InMemoryRedisClient = require('./cache/inMemoryRedisClient');
+const InMemoryPostgresClient = require('./infrastructure/inMemoryPostgres');
+const RiskRepository = require('./repositories/riskRepository');
+const AuditRepository = require('./repositories/auditRepository');
+const RiskEngine = require('./services/riskEngine');
+const AuditEngine = require('./services/auditEngine');
+const FeedbackService = require('./services/feedback');
+const CoreIntegrationService = require('./services/coreIntegration');
+const COSOService = require('./services/coso');
+const IIAService = require('./services/iia');
+const createRiskRouter = require('./apis/risk');
+const createAuditRouter = require('./apis/audit');
+const createReportRouter = require('./apis/report');
+const createAuthRouter = require('./apis/auth');
+const buildOpenApiSpec = require('./openapi/spec');
+
+function createApp(options = {}) {
+  const app = express();
+  app.use(express.json());
+
+  const eventBus = options.eventBus || new EventBus();
+  const redisClient = options.redisClient || new InMemoryRedisClient();
+  const cache = options.cache || new RedisCache(redisClient);
+  const dbClient = options.dbClient || new InMemoryPostgresClient();
+
+  const riskRepository = options.riskRepository || new RiskRepository(dbClient, cache);
+  const auditRepository = options.auditRepository || new AuditRepository(dbClient, cache);
+  const coso = options.coso || new COSOService();
+  const iia = options.iia || new IIAService();
+  const coreIntegration = options.coreIntegration || new CoreIntegrationService(eventBus);
+  const feedbackService = options.feedbackService || new FeedbackService();
+
+  const riskEngine = options.riskEngine || new RiskEngine({
+    riskRepository,
+    eventBus,
+    coreIntegration,
+    coso,
+  });
+
+  const auditEngine = options.auditEngine || new AuditEngine({
+    auditRepository,
+    riskEngine,
+    eventBus,
+    coreIntegration,
+    iia,
+  });
+
+  app.locals.eventBus = eventBus;
+  app.locals.riskEngine = riskEngine;
+  app.locals.auditEngine = auditEngine;
+  app.locals.feedbackService = feedbackService;
+  app.locals.coso = coso;
+  app.locals.iia = iia;
+  app.locals.repositories = { riskRepository, auditRepository };
+  app.locals.cache = cache;
+  app.locals.coreIntegration = coreIntegration;
+
+  app.use('/risks', createRiskRouter({ riskEngine }));
+  app.use('/audits', createAuditRouter({ auditEngine }));
+  app.use('/reports', createReportRouter({ riskEngine, auditEngine, feedbackService, coso }));
+  app.use('/auth', createAuthRouter({ eventBus }));
+
+  const openApiDocument = buildOpenApiSpec();
+  app.locals.openApiDocument = openApiDocument;
+  app.get('/openapi.json', (req, res) => {
+    res.json(openApiDocument);
+  });
+
+  return {
+    app,
+    eventBus,
+    riskEngine,
+    auditEngine,
+    feedbackService,
+    coreIntegration,
+    repositories: {
+      riskRepository,
+      auditRepository,
+    },
+    cache,
+    openApiDocument,
+  };
+}
+
+module.exports = { createApp };

--- a/backend/cache/inMemoryRedisClient.js
+++ b/backend/cache/inMemoryRedisClient.js
@@ -1,0 +1,34 @@
+class InMemoryRedisClient {
+  constructor() {
+    this.store = new Map();
+  }
+
+  async get(key) {
+    if (!this.store.has(key)) {
+      return null;
+    }
+    const entry = this.store.get(key);
+    if (entry.expiresAt && entry.expiresAt < Date.now()) {
+      this.store.delete(key);
+      return null;
+    }
+    return entry.value;
+  }
+
+  async set(key, value, ttlSeconds) {
+    const expiresAt = ttlSeconds ? Date.now() + ttlSeconds * 1000 : null;
+    this.store.set(key, { value, expiresAt });
+    return 'OK';
+  }
+
+  async del(key) {
+    this.store.delete(key);
+    return 1;
+  }
+
+  async flushAll() {
+    this.store.clear();
+  }
+}
+
+module.exports = InMemoryRedisClient;

--- a/backend/cache/redisCache.js
+++ b/backend/cache/redisCache.js
@@ -1,0 +1,35 @@
+class RedisCache {
+  constructor(client) {
+    this.client = client;
+  }
+
+  async get(key) {
+    const value = await this.client.get(key);
+    if (value === null || value === undefined) {
+      return null;
+    }
+    try {
+      return JSON.parse(value);
+    } catch (err) {
+      return value;
+    }
+  }
+
+  async set(key, value, ttlSeconds) {
+    const payload = typeof value === 'string' ? value : JSON.stringify(value);
+    if (typeof this.client.set === 'function') {
+      await this.client.set(key, payload, ttlSeconds);
+    }
+  }
+
+  async invalidate(keys) {
+    const list = Array.isArray(keys) ? keys : [keys];
+    for (const key of list) {
+      if (typeof this.client.del === 'function') {
+        await this.client.del(key);
+      }
+    }
+  }
+}
+
+module.exports = RedisCache;

--- a/backend/domain/auditEngagement.js
+++ b/backend/domain/auditEngagement.js
@@ -1,0 +1,22 @@
+const { z } = require('../lib/zod');
+const { FindingSchema } = require('./finding');
+
+const AuditEngagementSchema = z.object({
+  id: z.string().uuid().optional(),
+  title: z.string().min(3, 'Audit title is required'),
+  objective: z.string().min(5, 'Audit objective must be at least 5 characters'),
+  leadAuditor: z.string().min(1, 'Lead auditor is required'),
+  startDate: z.string().optional(),
+  endDate: z.string().optional(),
+  status: z.enum(['planned', 'in_progress', 'completed']).default('planned'),
+  riskIds: z.array(z.string().uuid()).default([]),
+  findings: z.array(FindingSchema).default([]),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+});
+
+function validateAuditEngagement(input) {
+  return AuditEngagementSchema.parse(input);
+}
+
+module.exports = { AuditEngagementSchema, validateAuditEngagement };

--- a/backend/domain/control.js
+++ b/backend/domain/control.js
@@ -1,0 +1,15 @@
+const { z } = require('../lib/zod');
+
+const ControlSchema = z.object({
+  id: z.string().uuid().optional(),
+  name: z.string().min(1, 'Control name is required'),
+  owner: z.string().min(1, 'Control owner is required'),
+  description: z.string().optional(),
+  status: z.enum(['effective', 'needs_improvement', 'ineffective']).default('effective'),
+});
+
+function validateControl(input) {
+  return ControlSchema.parse(input);
+}
+
+module.exports = { ControlSchema, validateControl };

--- a/backend/domain/finding.js
+++ b/backend/domain/finding.js
@@ -1,0 +1,17 @@
+const { z } = require('../lib/zod');
+
+const FindingSchema = z.object({
+  id: z.string().uuid().optional(),
+  title: z.string().min(1, 'Finding title is required'),
+  description: z.string().min(1, 'Finding description is required'),
+  severity: z.enum(['low', 'medium', 'high', 'critical']).default('medium'),
+  remediation: z.string().optional(),
+  owner: z.string().optional(),
+  dueDate: z.string().optional(),
+});
+
+function validateFinding(input) {
+  return FindingSchema.parse(input);
+}
+
+module.exports = { FindingSchema, validateFinding };

--- a/backend/domain/risk.js
+++ b/backend/domain/risk.js
@@ -1,0 +1,23 @@
+const { z } = require('../lib/zod');
+const { ControlSchema } = require('./control');
+
+const RiskSchema = z.object({
+  id: z.string().uuid().optional(),
+  title: z.string().min(3, 'Risk title must have at least 3 characters'),
+  description: z.string().min(5, 'Risk description must have at least 5 characters'),
+  category: z.enum(['strategic', 'financial', 'operational', 'compliance']).default('operational'),
+  inherentImpact: z.number().min(1).max(5).default(3),
+  inherentLikelihood: z.number().min(1).max(5).default(3),
+  residualScore: z.number().min(0).max(25).optional(),
+  owner: z.string().min(1, 'Risk owner is required'),
+  controls: z.array(ControlSchema).default([]),
+  status: z.enum(['open', 'mitigated', 'closed']).default('open'),
+  createdAt: z.string().optional(),
+  updatedAt: z.string().optional(),
+});
+
+function validateRisk(input) {
+  return RiskSchema.parse(input);
+}
+
+module.exports = { RiskSchema, validateRisk };

--- a/backend/framework/express.js
+++ b/backend/framework/express.js
@@ -1,0 +1,238 @@
+const http = require('http');
+const { URL } = require('url');
+
+const METHODS = ['GET', 'POST', 'PUT', 'DELETE'];
+
+function normalizePath(base, path) {
+  if (!base) return path || '/';
+  if (!path || path === '/') return base.startsWith('/') ? base : `/${base}`;
+  const separator = base.endsWith('/') ? '' : '/';
+  const formattedBase = base.startsWith('/') ? base : `/${base}`;
+  return `${formattedBase}${separator}${path.startsWith('/') ? path.substring(1) : path}`;
+}
+
+function splitPath(path) {
+  if (!path) return [];
+  return path.split('/').filter(Boolean);
+}
+
+function matchRoute(routePath, actualPath) {
+  const routeSegments = splitPath(routePath);
+  const pathSegments = splitPath(actualPath);
+
+  if (routeSegments.length !== pathSegments.length) {
+    if (routeSegments.length === 0 && pathSegments.length === 0) {
+      return { params: {} };
+    }
+    return null;
+  }
+
+  const params = {};
+  for (let i = 0; i < routeSegments.length; i += 1) {
+    const routeSegment = routeSegments[i];
+    const actualSegment = pathSegments[i];
+
+    if (routeSegment.startsWith(':')) {
+      params[routeSegment.slice(1)] = decodeURIComponent(actualSegment);
+      continue;
+    }
+
+    if (routeSegment !== actualSegment) {
+      return null;
+    }
+  }
+
+  return { params };
+}
+
+function decorateResponse(res) {
+  res.status = function status(code) {
+    res.statusCode = code;
+    return res;
+  };
+
+  res.json = function json(payload) {
+    if (!res.headersSent) {
+      res.setHeader('Content-Type', 'application/json');
+    }
+    const body = payload === undefined ? 'null' : JSON.stringify(payload);
+    res.end(body);
+  };
+
+  res.send = function send(payload) {
+    if (typeof payload === 'object') {
+      res.json(payload);
+      return;
+    }
+    if (!res.headersSent) {
+      res.setHeader('Content-Type', 'text/plain');
+    }
+    res.end(payload);
+  };
+
+  return res;
+}
+
+class Router {
+  constructor() {
+    this.__isRouter = true;
+    this.routes = [];
+    this.middlewares = [];
+  }
+
+  use(middleware) {
+    this.middlewares.push(middleware);
+  }
+
+  register(method, path, handler) {
+    if (!METHODS.includes(method)) {
+      throw new Error(`Unsupported method: ${method}`);
+    }
+    this.routes.push({ method, path: path || '/', handler });
+  }
+
+  get(path, handler) {
+    this.register('GET', path, handler);
+  }
+
+  post(path, handler) {
+    this.register('POST', path, handler);
+  }
+
+  put(path, handler) {
+    this.register('PUT', path, handler);
+  }
+
+  delete(path, handler) {
+    this.register('DELETE', path, handler);
+  }
+}
+
+class Application extends Router {
+  constructor() {
+    super();
+    this.locals = {};
+    this.server = null;
+  }
+
+  use(pathOrMiddleware, maybeRouter) {
+    if (typeof pathOrMiddleware === 'string' && maybeRouter && maybeRouter.__isRouter) {
+      const basePath = pathOrMiddleware;
+      maybeRouter.routes.forEach((route) => {
+        const combinedPath = normalizePath(basePath, route.path);
+        this.routes.push({ method: route.method, path: combinedPath || '/', handler: route.handler, middlewares: maybeRouter.middlewares });
+      });
+      return;
+    }
+
+    if (pathOrMiddleware && pathOrMiddleware.__isRouter) {
+      pathOrMiddleware.routes.forEach((route) => {
+        this.routes.push({ method: route.method, path: route.path || '/', handler: route.handler, middlewares: pathOrMiddleware.middlewares });
+      });
+      return;
+    }
+
+    this.middlewares.push(pathOrMiddleware);
+  }
+
+  handleRequest(req, res) {
+    decorateResponse(res);
+
+    const url = new URL(req.url, `http://${req.headers.host || 'localhost'}`);
+    req.path = url.pathname;
+    req.query = Object.fromEntries(url.searchParams.entries());
+    req.params = {};
+
+    const allMiddlewares = [...this.middlewares];
+
+    const runMiddlewares = (middlewares, index, done) => {
+      if (index >= middlewares.length) {
+        done();
+        return;
+      }
+      try {
+        middlewares[index](req, res, () => runMiddlewares(middlewares, index + 1, done));
+      } catch (err) {
+        this.handleError(err, res);
+      }
+    };
+
+    const handleRoute = () => {
+      for (const route of this.routes) {
+        if (route.method !== req.method) {
+          continue;
+        }
+        const match = matchRoute(route.path || '/', req.path || '/');
+        if (match) {
+          req.params = match.params;
+          const routeMiddlewares = route.middlewares || [];
+          runMiddlewares(routeMiddlewares, 0, () => {
+            try {
+              route.handler(req, res);
+            } catch (err) {
+              this.handleError(err, res);
+            }
+          });
+          return;
+        }
+      }
+      res.status(404).json({ error: 'Not Found' });
+    };
+
+    runMiddlewares(allMiddlewares, 0, handleRoute);
+  }
+
+  handleError(err, res) {
+    if (res.headersSent) {
+      res.end();
+      return;
+    }
+    res.status(err.statusCode || 500).json({ error: err.message || 'Internal Server Error' });
+  }
+
+  listen(port, callback) {
+    if (this.server) {
+      throw new Error('Application already listening');
+    }
+    this.server = http.createServer(this.handleRequest.bind(this));
+    return this.server.listen(port, callback);
+  }
+}
+
+function express() {
+  return new Application();
+}
+
+express.Router = function routerFactory() {
+  return new Router();
+};
+
+express.json = function jsonParser() {
+  return (req, res, next) => {
+    if (req.method === 'GET' || req.method === 'DELETE') {
+      req.body = {};
+      next();
+      return;
+    }
+
+    let data = '';
+    req.on('data', (chunk) => {
+      data += chunk;
+    });
+    req.on('end', () => {
+      if (!data) {
+        req.body = {};
+        next();
+        return;
+      }
+      try {
+        req.body = JSON.parse(data);
+        next();
+      } catch (err) {
+        res.status(400).json({ error: 'Invalid JSON payload' });
+      }
+    });
+  };
+};
+
+module.exports = express;

--- a/backend/infrastructure/inMemoryPostgres.js
+++ b/backend/infrastructure/inMemoryPostgres.js
@@ -1,0 +1,100 @@
+class InMemoryPostgresClient {
+  constructor() {
+    this.tables = {
+      risks: new Map(),
+      audits: new Map(),
+    };
+  }
+
+  async query(sql, params = []) {
+    const normalized = sql.trim().toLowerCase();
+
+    if (normalized.startsWith('select') && normalized.includes('from risks')) {
+      if (normalized.includes('where id')) {
+        const id = params[0];
+        const row = this.tables.risks.get(id);
+        return { rows: row ? [row] : [] };
+      }
+      const rows = Array.from(this.tables.risks.values()).sort((a, b) => {
+        const dateA = new Date(a.createdAt || 0).getTime();
+        const dateB = new Date(b.createdAt || 0).getTime();
+        return dateB - dateA;
+      });
+      return { rows };
+    }
+
+    if (normalized.startsWith('insert into risks')) {
+      const [id, payload] = params;
+      const record = {
+        ...payload,
+        id,
+        createdAt: payload.createdAt || new Date().toISOString(),
+        updatedAt: payload.updatedAt || payload.createdAt || new Date().toISOString(),
+      };
+      this.tables.risks.set(id, record);
+      return { rows: [record] };
+    }
+
+    if (normalized.startsWith('update risks')) {
+      const [payload, id] = params;
+      if (!this.tables.risks.has(id)) {
+        return { rows: [] };
+      }
+      const existing = this.tables.risks.get(id);
+      const record = {
+        ...existing,
+        ...payload,
+        id,
+        updatedAt: payload.updatedAt || new Date().toISOString(),
+      };
+      this.tables.risks.set(id, record);
+      return { rows: [record] };
+    }
+
+    if (normalized.startsWith('select') && normalized.includes('from audits')) {
+      if (normalized.includes('where id')) {
+        const id = params[0];
+        const row = this.tables.audits.get(id);
+        return { rows: row ? [row] : [] };
+      }
+      const rows = Array.from(this.tables.audits.values()).sort((a, b) => {
+        const dateA = new Date(a.createdAt || 0).getTime();
+        const dateB = new Date(b.createdAt || 0).getTime();
+        return dateB - dateA;
+      });
+      return { rows };
+    }
+
+    if (normalized.startsWith('insert into audits')) {
+      const [id, payload] = params;
+      const record = {
+        ...payload,
+        id,
+        createdAt: payload.createdAt || new Date().toISOString(),
+        updatedAt: payload.updatedAt || payload.createdAt || new Date().toISOString(),
+      };
+      this.tables.audits.set(id, record);
+      return { rows: [record] };
+    }
+
+    if (normalized.startsWith('update audits')) {
+      const [payload, id] = params;
+      if (!this.tables.audits.has(id)) {
+        return { rows: [] };
+      }
+      const existing = this.tables.audits.get(id);
+      const record = {
+        ...existing,
+        ...payload,
+        id,
+        updatedAt: payload.updatedAt || new Date().toISOString(),
+      };
+      this.tables.audits.set(id, record);
+      return { rows: [record] };
+    }
+
+    throw new Error(`Unsupported query: ${sql}`);
+  }
+}
+
+module.exports = InMemoryPostgresClient;

--- a/backend/lib/zod.js
+++ b/backend/lib/zod.js
@@ -1,0 +1,370 @@
+class BaseSchema {
+  constructor(validator) {
+    this.validator = validator;
+    this._isOptional = false;
+    this._defaultValue = undefined;
+    this._hasDefault = false;
+    this._refinements = [];
+  }
+
+  optional() {
+    const clone = this._clone();
+    clone._isOptional = true;
+    return clone;
+  }
+
+  default(value) {
+    const clone = this._clone();
+    clone._defaultValue = value;
+    clone._hasDefault = true;
+    return clone;
+  }
+
+  refine(check, message = 'Validation failed') {
+    const clone = this._clone();
+    clone._refinements.push({ check, message });
+    return clone;
+  }
+
+  _clone() {
+    const clone = new BaseSchema(this.validator);
+    clone._isOptional = this._isOptional;
+    clone._defaultValue = this._defaultValue;
+    clone._hasDefault = this._hasDefault;
+    clone._refinements = [...this._refinements];
+    return clone;
+  }
+
+  parse(value) {
+    if (value === undefined || value === null) {
+      if (this._hasDefault) {
+        return typeof this._defaultValue === 'function'
+          ? this._defaultValue()
+          : this._defaultValue;
+      }
+      if (this._isOptional) {
+        return undefined;
+      }
+      throw new Error('Value is required');
+    }
+    const parsed = this.validator(value);
+    for (const refinement of this._refinements) {
+      if (!refinement.check(parsed)) {
+        throw new Error(refinement.message);
+      }
+    }
+    return parsed;
+  }
+}
+
+class StringSchema extends BaseSchema {
+  constructor() {
+    super((value) => {
+      if (typeof value !== 'string') {
+        throw new Error('Expected string');
+      }
+      return value;
+    });
+    this._min = null;
+    this._max = null;
+    this._uuid = false;
+    this._email = false;
+  }
+
+  _clone() {
+    const clone = new StringSchema();
+    clone._isOptional = this._isOptional;
+    clone._defaultValue = this._defaultValue;
+    clone._hasDefault = this._hasDefault;
+    clone._refinements = [...this._refinements];
+    clone._min = this._min;
+    clone._max = this._max;
+    clone._uuid = this._uuid;
+    clone._email = this._email;
+    return clone;
+  }
+
+  min(length, message = `Expected at least ${length} characters`) {
+    const clone = this._clone();
+    clone._min = { length, message };
+    clone.validator = (value) => {
+      if (typeof value !== 'string') {
+        throw new Error('Expected string');
+      }
+      if (value.length < length) {
+        throw new Error(message);
+      }
+      if (clone._max && value.length > clone._max.length) {
+        throw new Error(clone._max.message);
+      }
+      if (clone._uuid) {
+        validateUuid(value, clone._uuidMessage);
+      }
+      if (clone._email && !/^\S+@\S+\.\S+$/.test(value)) {
+        throw new Error('Invalid email address');
+      }
+      return value;
+    };
+    return clone;
+  }
+
+  max(length, message = `Expected at most ${length} characters`) {
+    const clone = this._clone();
+    clone._max = { length, message };
+    clone.validator = (value) => {
+      if (typeof value !== 'string') {
+        throw new Error('Expected string');
+      }
+      if (clone._min && value.length < clone._min.length) {
+        throw new Error(clone._min.message);
+      }
+      if (value.length > length) {
+        throw new Error(message);
+      }
+      if (clone._uuid) {
+        validateUuid(value, clone._uuidMessage);
+      }
+      if (clone._email && !/^\S+@\S+\.\S+$/.test(value)) {
+        throw new Error('Invalid email address');
+      }
+      return value;
+    };
+    return clone;
+  }
+
+  uuid(message = 'Invalid UUID') {
+    const clone = this._clone();
+    clone._uuid = true;
+    clone._uuidMessage = message;
+    clone.validator = (value) => {
+      if (typeof value !== 'string') {
+        throw new Error('Expected string');
+      }
+      validateUuid(value, message);
+      if (clone._min && value.length < clone._min.length) {
+        throw new Error(clone._min.message);
+      }
+      if (clone._max && value.length > clone._max.length) {
+        throw new Error(clone._max.message);
+      }
+      return value;
+    };
+    return clone;
+  }
+
+  email() {
+    const clone = this._clone();
+    clone._email = true;
+    clone.validator = (value) => {
+      if (typeof value !== 'string') {
+        throw new Error('Expected string');
+      }
+      if (!/^\S+@\S+\.\S+$/.test(value)) {
+        throw new Error('Invalid email address');
+      }
+      if (clone._min && value.length < clone._min.length) {
+        throw new Error(clone._min.message);
+      }
+      if (clone._max && value.length > clone._max.length) {
+        throw new Error(clone._max.message);
+      }
+      return value;
+    };
+    return clone;
+  }
+}
+
+class NumberSchema extends BaseSchema {
+  constructor() {
+    super((value) => {
+      if (typeof value !== 'number' || Number.isNaN(value)) {
+        throw new Error('Expected number');
+      }
+      return value;
+    });
+    this._min = null;
+    this._max = null;
+    this._int = false;
+  }
+
+  _clone() {
+    const clone = new NumberSchema();
+    clone._isOptional = this._isOptional;
+    clone._defaultValue = this._defaultValue;
+    clone._hasDefault = this._hasDefault;
+    clone._refinements = [...this._refinements];
+    clone._min = this._min;
+    clone._max = this._max;
+    clone._int = this._int;
+    return clone;
+  }
+
+  min(value, message = `Expected number >= ${value}`) {
+    const clone = this._clone();
+    clone._min = { value, message };
+    clone.validator = (input) => {
+      if (typeof input !== 'number' || Number.isNaN(input)) {
+        throw new Error('Expected number');
+      }
+      if (clone._int && !Number.isInteger(input)) {
+        throw new Error('Expected integer');
+      }
+      if (input < value) {
+        throw new Error(message);
+      }
+      if (clone._max && input > clone._max.value) {
+        throw new Error(clone._max.message);
+      }
+      return input;
+    };
+    return clone;
+  }
+
+  max(value, message = `Expected number <= ${value}`) {
+    const clone = this._clone();
+    clone._max = { value, message };
+    clone.validator = (input) => {
+      if (typeof input !== 'number' || Number.isNaN(input)) {
+        throw new Error('Expected number');
+      }
+      if (clone._int && !Number.isInteger(input)) {
+        throw new Error('Expected integer');
+      }
+      if (clone._min && input < clone._min.value) {
+        throw new Error(clone._min.message);
+      }
+      if (input > value) {
+        throw new Error(message);
+      }
+      return input;
+    };
+    return clone;
+  }
+
+  int(message = 'Expected integer') {
+    const clone = this._clone();
+    clone._int = true;
+    clone.validator = (input) => {
+      if (typeof input !== 'number' || Number.isNaN(input) || !Number.isInteger(input)) {
+        throw new Error(message);
+      }
+      if (clone._min && input < clone._min.value) {
+        throw new Error(clone._min.message);
+      }
+      if (clone._max && input > clone._max.value) {
+        throw new Error(clone._max.message);
+      }
+      return input;
+    };
+    return clone;
+  }
+}
+
+class BooleanSchema extends BaseSchema {
+  constructor() {
+    super((value) => {
+      if (typeof value !== 'boolean') {
+        throw new Error('Expected boolean');
+      }
+      return value;
+    });
+  }
+
+  _clone() {
+    const clone = new BooleanSchema();
+    clone._isOptional = this._isOptional;
+    clone._defaultValue = this._defaultValue;
+    clone._hasDefault = this._hasDefault;
+    clone._refinements = [...this._refinements];
+    return clone;
+  }
+}
+
+class EnumSchema extends BaseSchema {
+  constructor(values) {
+    super((value) => {
+      if (!values.includes(value)) {
+        throw new Error(`Expected one of: ${values.join(', ')}`);
+      }
+      return value;
+    });
+    this.values = values;
+  }
+
+  _clone() {
+    const clone = new EnumSchema(this.values);
+    clone._isOptional = this._isOptional;
+    clone._defaultValue = this._defaultValue;
+    clone._hasDefault = this._hasDefault;
+    clone._refinements = [...this._refinements];
+    return clone;
+  }
+}
+
+class ArraySchema extends BaseSchema {
+  constructor(itemSchema) {
+    super((value) => {
+      if (!Array.isArray(value)) {
+        throw new Error('Expected array');
+      }
+      return value.map((item) => itemSchema.parse(item));
+    });
+    this.itemSchema = itemSchema;
+  }
+
+  _clone() {
+    const clone = new ArraySchema(this.itemSchema);
+    clone._isOptional = this._isOptional;
+    clone._defaultValue = this._defaultValue;
+    clone._hasDefault = this._hasDefault;
+    clone._refinements = [...this._refinements];
+    return clone;
+  }
+}
+
+class ObjectSchema extends BaseSchema {
+  constructor(shape) {
+    super((value) => {
+      if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+        throw new Error('Expected object');
+      }
+      const result = {};
+      for (const [key, schema] of Object.entries(shape)) {
+        result[key] = schema.parse(value[key]);
+      }
+      return result;
+    });
+    this.shape = shape;
+  }
+
+  _clone() {
+    const clone = new ObjectSchema(this.shape);
+    clone._isOptional = this._isOptional;
+    clone._defaultValue = this._defaultValue;
+    clone._hasDefault = this._hasDefault;
+    clone._refinements = [...this._refinements];
+    return clone;
+  }
+
+  extend(extension) {
+    return new ObjectSchema({ ...this.shape, ...extension });
+  }
+}
+
+function validateUuid(value, message) {
+  const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  if (!uuidRegex.test(value)) {
+    throw new Error(message);
+  }
+}
+
+const z = {
+  string: () => new StringSchema(),
+  number: () => new NumberSchema(),
+  boolean: () => new BooleanSchema(),
+  enum: (values) => new EnumSchema(values),
+  array: (schema) => new ArraySchema(schema),
+  object: (shape) => new ObjectSchema(shape),
+};
+
+module.exports = { z, BaseSchema, StringSchema, NumberSchema, BooleanSchema, EnumSchema, ArraySchema, ObjectSchema };

--- a/backend/mq/eventBus.js
+++ b/backend/mq/eventBus.js
@@ -1,0 +1,40 @@
+class EventBus {
+  constructor() {
+    this.subscribers = new Map();
+    this.published = [];
+  }
+
+  publish(eventName, payload) {
+    const record = { event: eventName, payload, publishedAt: new Date().toISOString() };
+    this.published.push(record);
+    const subscribers = this.subscribers.get(eventName) || [];
+    subscribers.forEach((handler) => {
+      try {
+        handler(payload);
+      } catch (err) {
+        // swallow errors in the stubbed bus to keep publishing resilient
+      }
+    });
+    return record;
+  }
+
+  subscribe(eventName, handler) {
+    const handlers = this.subscribers.get(eventName) || [];
+    handlers.push(handler);
+    this.subscribers.set(eventName, handlers);
+    return () => {
+      const current = this.subscribers.get(eventName) || [];
+      this.subscribers.set(
+        eventName,
+        current.filter((fn) => fn !== handler),
+      );
+    };
+  }
+
+  clear() {
+    this.subscribers.clear();
+    this.published = [];
+  }
+}
+
+module.exports = EventBus;

--- a/backend/openapi/spec.js
+++ b/backend/openapi/spec.js
@@ -1,0 +1,259 @@
+function buildOpenApiSpec() {
+  return {
+    openapi: '3.0.0',
+    info: {
+      title: 'Governance, Risk and Compliance Platform API',
+      version: '1.0.0',
+      description: 'Unified API for risk, audit, reporting, and authentication services.',
+    },
+    servers: [
+      { url: 'http://localhost:3000', description: 'Local development' },
+    ],
+    paths: {
+      '/auth/health': {
+        get: {
+          summary: 'Health check for authentication service',
+          responses: {
+            200: {
+              description: 'Service is healthy',
+              content: { 'application/json': { schema: { type: 'object', properties: { status: { type: 'string' } } } } },
+            },
+          },
+        },
+      },
+      '/auth/login': {
+        post: {
+          summary: 'Authenticate a user',
+          requestBody: {
+            required: true,
+            content: {
+              'application/json': {
+                schema: {
+                  type: 'object',
+                  properties: {
+                    username: { type: 'string' },
+                    password: { type: 'string' },
+                  },
+                  required: ['username', 'password'],
+                },
+              },
+            },
+          },
+          responses: {
+            200: {
+              description: 'Authentication successful',
+              content: { 'application/json': { schema: { type: 'object', properties: { token: { type: 'string' }, expiresIn: { type: 'integer' } } } } },
+            },
+            400: { description: 'Invalid request' },
+          },
+        },
+      },
+      '/risks': {
+        get: {
+          summary: 'List all risks',
+          responses: {
+            200: {
+              description: 'Risk collection',
+              content: { 'application/json': { schema: { type: 'object', properties: { data: { type: 'array', items: { $ref: '#/components/schemas/Risk' } } } } } },
+            },
+          },
+        },
+        post: {
+          summary: 'Create a new risk',
+          requestBody: {
+            required: true,
+            content: { 'application/json': { schema: { $ref: '#/components/schemas/Risk' } } },
+          },
+          responses: {
+            201: { description: 'Risk created', content: { 'application/json': { schema: { type: 'object', properties: { data: { $ref: '#/components/schemas/Risk' } } } } } },
+            400: { description: 'Validation error' },
+          },
+        },
+      },
+      '/risks/{id}': {
+        put: {
+          summary: 'Update an existing risk',
+          parameters: [
+            { name: 'id', in: 'path', required: true, schema: { type: 'string', format: 'uuid' } },
+          ],
+          requestBody: {
+            required: true,
+            content: { 'application/json': { schema: { $ref: '#/components/schemas/Risk' } } },
+          },
+          responses: {
+            200: { description: 'Risk updated', content: { 'application/json': { schema: { type: 'object', properties: { data: { $ref: '#/components/schemas/Risk' } } } } } },
+            400: { description: 'Validation error' },
+            404: { description: 'Risk not found' },
+          },
+        },
+      },
+      '/audits': {
+        get: {
+          summary: 'List audit engagements',
+          responses: {
+            200: {
+              description: 'Audit collection',
+              content: { 'application/json': { schema: { type: 'object', properties: { data: { type: 'array', items: { $ref: '#/components/schemas/AuditEngagement' } } } } } },
+            },
+          },
+        },
+        post: {
+          summary: 'Plan an audit engagement',
+          requestBody: {
+            required: true,
+            content: { 'application/json': { schema: { $ref: '#/components/schemas/AuditEngagement' } } },
+          },
+          responses: {
+            201: { description: 'Audit planned', content: { 'application/json': { schema: { type: 'object', properties: { data: { $ref: '#/components/schemas/AuditEngagement' } } } } } },
+            400: { description: 'Validation error' },
+          },
+        },
+      },
+      '/audits/{id}/findings': {
+        post: {
+          summary: 'Attach a finding to an audit',
+          parameters: [
+            { name: 'id', in: 'path', required: true, schema: { type: 'string', format: 'uuid' } },
+          ],
+          requestBody: {
+            required: true,
+            content: { 'application/json': { schema: { $ref: '#/components/schemas/Finding' } } },
+          },
+          responses: {
+            200: { description: 'Finding added', content: { 'application/json': { schema: { type: 'object', properties: { data: { $ref: '#/components/schemas/AuditEngagement' } } } } } },
+            400: { description: 'Validation error' },
+            404: { description: 'Audit not found' },
+          },
+        },
+      },
+      '/reports': {
+        get: {
+          summary: 'Retrieve analytics report',
+          responses: {
+            200: {
+              description: 'Aggregated report data',
+              content: {
+                'application/json': {
+                  schema: {
+                    type: 'object',
+                    properties: {
+                      data: {
+                        type: 'object',
+                        properties: {
+                          totalRisks: { type: 'integer' },
+                          totalAudits: { type: 'integer' },
+                          averageResidualScore: { type: 'number' },
+                          averageAuditReadiness: { type: 'number' },
+                          openRisks: { type: 'integer' },
+                          completedAudits: { type: 'integer' },
+                          feedback: { type: 'array', items: { $ref: '#/components/schemas/Feedback' } },
+                        },
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+      '/reports/feedback': {
+        get: {
+          summary: 'List feedback items for reports',
+          responses: {
+            200: {
+              description: 'Feedback collection',
+              content: { 'application/json': { schema: { type: 'object', properties: { data: { type: 'array', items: { $ref: '#/components/schemas/Feedback' } } } } } },
+            },
+          },
+        },
+        post: {
+          summary: 'Submit feedback for reports',
+          requestBody: {
+            required: true,
+            content: { 'application/json': { schema: { type: 'object' } } },
+          },
+          responses: {
+            201: {
+              description: 'Feedback recorded',
+              content: { 'application/json': { schema: { type: 'object', properties: { data: { $ref: '#/components/schemas/Feedback' } } } } },
+            },
+          },
+        },
+      },
+    },
+    components: {
+      schemas: {
+        Control: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', format: 'uuid' },
+            name: { type: 'string' },
+            owner: { type: 'string' },
+            description: { type: 'string' },
+            status: { type: 'string', enum: ['effective', 'needs_improvement', 'ineffective'] },
+          },
+        },
+        Risk: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', format: 'uuid' },
+            title: { type: 'string' },
+            description: { type: 'string' },
+            category: { type: 'string', enum: ['strategic', 'financial', 'operational', 'compliance'] },
+            inherentImpact: { type: 'number' },
+            inherentLikelihood: { type: 'number' },
+            residualScore: { type: 'number' },
+            owner: { type: 'string' },
+            controls: { type: 'array', items: { $ref: '#/components/schemas/Control' } },
+            status: { type: 'string', enum: ['open', 'mitigated', 'closed'] },
+            createdAt: { type: 'string', format: 'date-time' },
+            updatedAt: { type: 'string', format: 'date-time' },
+          },
+          required: ['title', 'description', 'owner'],
+        },
+        Finding: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', format: 'uuid' },
+            title: { type: 'string' },
+            description: { type: 'string' },
+            severity: { type: 'string', enum: ['low', 'medium', 'high', 'critical'] },
+            remediation: { type: 'string' },
+            owner: { type: 'string' },
+            dueDate: { type: 'string', format: 'date' },
+          },
+          required: ['title', 'description', 'severity'],
+        },
+        AuditEngagement: {
+          type: 'object',
+          properties: {
+            id: { type: 'string', format: 'uuid' },
+            title: { type: 'string' },
+            objective: { type: 'string' },
+            leadAuditor: { type: 'string' },
+            startDate: { type: 'string', format: 'date' },
+            endDate: { type: 'string', format: 'date' },
+            status: { type: 'string', enum: ['planned', 'in_progress', 'completed'] },
+            riskIds: { type: 'array', items: { type: 'string', format: 'uuid' } },
+            findings: { type: 'array', items: { $ref: '#/components/schemas/Finding' } },
+            readinessScore: { type: 'number' },
+            coverage: { type: 'number' },
+          },
+          required: ['title', 'objective', 'leadAuditor'],
+        },
+        Feedback: {
+          type: 'object',
+          properties: {
+            id: { type: 'string' },
+            type: { type: 'string' },
+            payload: { type: 'object' },
+            createdAt: { type: 'string', format: 'date-time' },
+          },
+        },
+      },
+    },
+  };
+}
+
+module.exports = buildOpenApiSpec;

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "backend",
+  "version": "1.0.0",
+  "description": "",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js",
+    "test": "node tests/run.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/backend/repositories/auditRepository.js
+++ b/backend/repositories/auditRepository.js
@@ -1,0 +1,47 @@
+class AuditRepository {
+  constructor(dbClient, cache) {
+    this.dbClient = dbClient;
+    this.cache = cache;
+  }
+
+  async getAllAudits() {
+    const cacheKey = 'audits:all';
+    const cached = await this.cache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+    const result = await this.dbClient.query('SELECT * FROM audits ORDER BY created_at DESC');
+    await this.cache.set(cacheKey, result.rows);
+    return result.rows;
+  }
+
+  async getAuditById(id) {
+    const cacheKey = `audit:${id}`;
+    const cached = await this.cache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+    const result = await this.dbClient.query('SELECT * FROM audits WHERE id = $1', [id]);
+    const audit = result.rows[0] || null;
+    if (audit) {
+      await this.cache.set(cacheKey, audit);
+    }
+    return audit;
+  }
+
+  async createAudit(audit) {
+    await this.dbClient.query('INSERT INTO audits(id, data) VALUES($1, $2)', [audit.id, audit]);
+    await this.cache.invalidate(['audits:all']);
+    await this.cache.set(`audit:${audit.id}`, audit);
+    return audit;
+  }
+
+  async updateAudit(audit) {
+    await this.dbClient.query('UPDATE audits SET data = $1 WHERE id = $2', [audit, audit.id]);
+    await this.cache.invalidate(['audits:all']);
+    await this.cache.set(`audit:${audit.id}`, audit);
+    return audit;
+  }
+}
+
+module.exports = AuditRepository;

--- a/backend/repositories/riskRepository.js
+++ b/backend/repositories/riskRepository.js
@@ -1,0 +1,47 @@
+class RiskRepository {
+  constructor(dbClient, cache) {
+    this.dbClient = dbClient;
+    this.cache = cache;
+  }
+
+  async getAllRisks() {
+    const cacheKey = 'risks:all';
+    const cached = await this.cache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+    const result = await this.dbClient.query('SELECT * FROM risks ORDER BY created_at DESC');
+    await this.cache.set(cacheKey, result.rows);
+    return result.rows;
+  }
+
+  async getRiskById(id) {
+    const cacheKey = `risk:${id}`;
+    const cached = await this.cache.get(cacheKey);
+    if (cached) {
+      return cached;
+    }
+    const result = await this.dbClient.query('SELECT * FROM risks WHERE id = $1', [id]);
+    const risk = result.rows[0] || null;
+    if (risk) {
+      await this.cache.set(cacheKey, risk);
+    }
+    return risk;
+  }
+
+  async createRisk(risk) {
+    await this.dbClient.query('INSERT INTO risks(id, data) VALUES($1, $2)', [risk.id, risk]);
+    await this.cache.invalidate(['risks:all']);
+    await this.cache.set(`risk:${risk.id}`, risk);
+    return risk;
+  }
+
+  async updateRisk(risk) {
+    await this.dbClient.query('UPDATE risks SET data = $1 WHERE id = $2', [risk, risk.id]);
+    await this.cache.invalidate(['risks:all']);
+    await this.cache.set(`risk:${risk.id}`, risk);
+    return risk;
+  }
+}
+
+module.exports = RiskRepository;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,0 +1,15 @@
+const { createApp } = require('./app');
+
+const PORT = process.env.PORT || 3000;
+
+const { app } = createApp();
+
+const server = app.listen(PORT, () => {
+  console.log(`Backend services listening on port ${PORT}`);
+});
+
+process.on('SIGINT', () => {
+  server.close(() => {
+    process.exit(0);
+  });
+});

--- a/backend/services/auditEngine.js
+++ b/backend/services/auditEngine.js
@@ -1,0 +1,62 @@
+const { randomUUID } = require('crypto');
+const { AuditEngagementSchema } = require('../domain/auditEngagement');
+const { FindingSchema } = require('../domain/finding');
+
+class AuditEngine {
+  constructor({ auditRepository, riskEngine, eventBus, coreIntegration, iia }) {
+    this.auditRepository = auditRepository;
+    this.riskEngine = riskEngine;
+    this.eventBus = eventBus;
+    this.coreIntegration = coreIntegration;
+    this.iia = iia;
+  }
+
+  async listAudits() {
+    return this.auditRepository.getAllAudits();
+  }
+
+  async planAudit(payload) {
+    const parsed = AuditEngagementSchema.parse(payload);
+    const timestamp = new Date().toISOString();
+    const audit = {
+      ...parsed,
+      id: parsed.id || randomUUID(),
+      createdAt: parsed.createdAt || timestamp,
+      updatedAt: parsed.updatedAt || timestamp,
+    };
+    audit.readinessScore = this.iia.evaluateEngagement(audit);
+    audit.coverage = await this.computeCoverage(audit);
+    await this.auditRepository.createAudit(audit);
+    await this.coreIntegration.notifyAudit(audit);
+    this.eventBus.publish('audit_planned', { id: audit.id, readinessScore: audit.readinessScore });
+    return audit;
+  }
+
+  async computeCoverage(audit) {
+    const risks = await this.riskEngine.listRisks();
+    if (!risks.length) {
+      return 0;
+    }
+    const targeted = risks.filter((risk) => (audit.riskIds || []).includes(risk.id));
+    return Math.round((targeted.length / risks.length) * 100);
+  }
+
+  async addFinding(auditId, payload) {
+    const audit = await this.auditRepository.getAuditById(auditId);
+    if (!audit) {
+      throw new Error('Audit not found');
+    }
+    const parsed = FindingSchema.parse(payload);
+    const finding = { ...parsed, id: parsed.id || randomUUID() };
+    const updated = {
+      ...audit,
+      findings: [...(audit.findings || []), finding],
+      updatedAt: new Date().toISOString(),
+    };
+    updated.readinessScore = this.iia.evaluateEngagement(updated);
+    await this.auditRepository.updateAudit(updated);
+    return updated;
+  }
+}
+
+module.exports = AuditEngine;

--- a/backend/services/coreIntegration.js
+++ b/backend/services/coreIntegration.js
@@ -1,0 +1,31 @@
+class CoreIntegrationService {
+  constructor(eventBus) {
+    this.eventBus = eventBus;
+    this.auditNotifications = [];
+    this.riskSyncLog = [];
+  }
+
+  async syncRisk(risk) {
+    const record = {
+      id: risk.id,
+      syncedAt: new Date().toISOString(),
+      status: 'synced',
+    };
+    this.riskSyncLog.push(record);
+    this.eventBus.publish('integration_risk_synced', { riskId: risk.id });
+    return record;
+  }
+
+  async notifyAudit(audit) {
+    const record = {
+      id: audit.id,
+      notifiedAt: new Date().toISOString(),
+      status: 'notified',
+    };
+    this.auditNotifications.push(record);
+    this.eventBus.publish('integration_audit_notified', { auditId: audit.id });
+    return record;
+  }
+}
+
+module.exports = CoreIntegrationService;

--- a/backend/services/coso.js
+++ b/backend/services/coso.js
@@ -1,0 +1,26 @@
+class COSOService {
+  calculateResidualScore(risk) {
+    const inherent = (risk.inherentImpact || 0) * (risk.inherentLikelihood || 0);
+    const controlModifier = (risk.controls || []).reduce((score, control) => {
+      if (control.status === 'effective') return score - 1;
+      if (control.status === 'needs_improvement') return score;
+      return score + 1;
+    }, 0);
+    const residual = Math.max(inherent + controlModifier, 0);
+    return residual;
+  }
+
+  evaluateControlEnvironment(risk) {
+    const total = (risk.controls || []).length;
+    if (total === 0) {
+      return 'insufficient';
+    }
+    const effective = (risk.controls || []).filter((control) => control.status === 'effective').length;
+    const ratio = effective / total;
+    if (ratio > 0.7) return 'strong';
+    if (ratio > 0.4) return 'moderate';
+    return 'weak';
+  }
+}
+
+module.exports = COSOService;

--- a/backend/services/feedback.js
+++ b/backend/services/feedback.js
@@ -1,0 +1,25 @@
+class FeedbackService {
+  constructor() {
+    this.records = [];
+  }
+
+  captureFeedback(type, payload) {
+    const entry = {
+      id: `${Date.now()}-${Math.random().toString(16).slice(2)}`,
+      type,
+      payload,
+      createdAt: new Date().toISOString(),
+    };
+    this.records.push(entry);
+    return entry;
+  }
+
+  getFeedback(type) {
+    if (!type) {
+      return [...this.records];
+    }
+    return this.records.filter((item) => item.type === type);
+  }
+}
+
+module.exports = FeedbackService;

--- a/backend/services/iia.js
+++ b/backend/services/iia.js
@@ -1,0 +1,26 @@
+class IIAService {
+  evaluateEngagement(audit) {
+    const statusScore = {
+      planned: 1,
+      in_progress: 2,
+      completed: 3,
+    }[audit.status] || 0;
+
+    const findingsPenalty = (audit.findings || []).reduce((penalty, finding) => {
+      switch (finding.severity) {
+        case 'critical':
+          return penalty + 4;
+        case 'high':
+          return penalty + 3;
+        case 'medium':
+          return penalty + 2;
+        default:
+          return penalty + 1;
+      }
+    }, 0);
+
+    return Math.max(statusScore * 10 - findingsPenalty, 0);
+  }
+}
+
+module.exports = IIAService;

--- a/backend/services/riskEngine.js
+++ b/backend/services/riskEngine.js
@@ -1,0 +1,47 @@
+const { randomUUID } = require('crypto');
+const { RiskSchema } = require('../domain/risk');
+
+class RiskEngine {
+  constructor({ riskRepository, eventBus, coreIntegration, coso }) {
+    this.riskRepository = riskRepository;
+    this.eventBus = eventBus;
+    this.coreIntegration = coreIntegration;
+    this.coso = coso;
+  }
+
+  async listRisks() {
+    return this.riskRepository.getAllRisks();
+  }
+
+  async createRisk(payload) {
+    const parsed = RiskSchema.parse(payload);
+    const timestamp = new Date().toISOString();
+    const risk = {
+      ...parsed,
+      id: parsed.id || randomUUID(),
+      createdAt: parsed.createdAt || timestamp,
+      updatedAt: parsed.updatedAt || timestamp,
+    };
+    risk.residualScore = this.coso.calculateResidualScore(risk);
+    await this.riskRepository.createRisk(risk);
+    await this.coreIntegration.syncRisk(risk);
+    this.eventBus.publish('risk_created', { id: risk.id, residualScore: risk.residualScore });
+    return risk;
+  }
+
+  async updateRisk(id, updates) {
+    const existing = await this.riskRepository.getRiskById(id);
+    if (!existing) {
+      throw new Error('Risk not found');
+    }
+    const merged = { ...existing, ...updates, id, updatedAt: new Date().toISOString() };
+    const parsed = RiskSchema.parse(merged);
+    parsed.residualScore = this.coso.calculateResidualScore(parsed);
+    await this.riskRepository.updateRisk(parsed);
+    await this.coreIntegration.syncRisk(parsed);
+    this.eventBus.publish('risk_updated', { id: parsed.id, residualScore: parsed.residualScore });
+    return parsed;
+  }
+}
+
+module.exports = RiskEngine;

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -1,0 +1,132 @@
+const { describe, it, expect, beforeEach, afterEach } = require('./jest-lite');
+const { createApp } = require('../app');
+
+let server;
+let baseUrl;
+
+async function request(path, options = {}) {
+  const response = await fetch(`${baseUrl}${path}`, options);
+  const contentType = response.headers.get('content-type') || '';
+  const body = contentType.includes('application/json') ? await response.json() : await response.text();
+  return { response, body };
+}
+
+describe('API integration', () => {
+  beforeEach(() => {
+    const { app } = createApp();
+    server = app.listen(0);
+    const { port } = server.address();
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterEach(async () => {
+    if (server) {
+      await new Promise((resolve) => server.close(resolve));
+    }
+  });
+
+  it('serves an OpenAPI document', async () => {
+    const { response, body } = await request('/openapi.json');
+    expect(response.status).toBe(200);
+    expect(body.openapi).toBe('3.0.0');
+    expect(!!body.paths['/risks']).toBeTruthy();
+  });
+
+  it('creates, updates, and lists risks', async () => {
+    const riskPayload = {
+      title: 'Data Privacy',
+      description: 'Potential breach of personal data',
+      owner: 'CISO',
+      inherentImpact: 5,
+      inherentLikelihood: 4,
+      controls: [
+        { name: 'Access Control', owner: 'Security', status: 'effective' },
+      ],
+    };
+
+    const creation = await request('/risks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(riskPayload),
+    });
+    expect(creation.response.status).toBe(201);
+    const createdRisk = creation.body.data;
+    expect(createdRisk.title).toBe('Data Privacy');
+
+    const update = await request(`/risks/${createdRisk.id}`, {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: 'mitigated' }),
+    });
+    expect(update.response.status).toBe(200);
+    expect(update.body.data.status).toBe('mitigated');
+
+    const list = await request('/risks');
+    expect(list.response.status).toBe(200);
+    expect(Array.isArray(list.body.data)).toBeTruthy();
+    expect(list.body.data.length).toBeGreaterThan(0);
+  });
+
+  it('plans audits and exposes aggregated reports with feedback', async () => {
+    const riskPayload = {
+      title: 'Regulatory Compliance',
+      description: 'Monitor compliance with new regulation',
+      owner: 'Compliance Lead',
+    };
+    const { body: riskBody } = await request('/risks', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(riskPayload),
+    });
+    const riskId = riskBody.data.id;
+
+    const auditPayload = {
+      title: 'Compliance Readiness',
+      objective: 'Assess regulatory controls',
+      leadAuditor: 'Jane Auditor',
+      riskIds: [riskId],
+    };
+    const auditResult = await request('/audits', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(auditPayload),
+    });
+    expect(auditResult.response.status).toBe(201);
+    const auditId = auditResult.body.data.id;
+
+    const findingResult = await request(`/audits/${auditId}/findings`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        title: 'Policy Gap',
+        description: 'Documented policy missing approval.',
+        severity: 'medium',
+      }),
+    });
+    expect(findingResult.response.status).toBe(200);
+
+    const feedbackResult = await request('/reports/feedback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ message: 'Report looks good' }),
+    });
+    expect(feedbackResult.response.status).toBe(201);
+
+    const report = await request('/reports');
+    expect(report.response.status).toBe(200);
+    expect(report.body.data.totalRisks).toBeGreaterThan(0);
+    expect(report.body.data.totalAudits).toBeGreaterThan(0);
+    expect(report.body.data.feedback.length).toBeGreaterThan(0);
+  });
+
+  it('authenticates users', async () => {
+    const login = await request('/auth/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ username: 'analyst', password: 'secret' }),
+    });
+    expect(login.response.status).toBe(200);
+    expect(typeof login.body.token).toBe('string');
+    expect(login.body.token.length).toBeGreaterThan(5);
+  });
+});

--- a/backend/tests/jest-lite.js
+++ b/backend/tests/jest-lite.js
@@ -1,0 +1,125 @@
+const assert = require('assert');
+
+const rootSuite = {
+  name: 'root',
+  suites: [],
+  tests: [],
+  beforeEach: [],
+  afterEach: [],
+};
+
+let currentSuite = rootSuite;
+
+function createSuite(name) {
+  return {
+    name,
+    suites: [],
+    tests: [],
+    beforeEach: [],
+    afterEach: [],
+  };
+}
+
+function describe(name, fn) {
+  const parent = currentSuite;
+  const suite = createSuite(name);
+  parent.suites.push(suite);
+  currentSuite = suite;
+  fn();
+  currentSuite = parent;
+}
+
+function it(name, fn) {
+  currentSuite.tests.push({ name, fn });
+}
+
+function beforeEach(fn) {
+  currentSuite.beforeEach.push(fn);
+}
+
+function afterEach(fn) {
+  currentSuite.afterEach.push(fn);
+}
+
+function expect(actual) {
+  return {
+    toEqual(expected) {
+      assert.deepStrictEqual(actual, expected);
+    },
+    toBe(expected) {
+      assert.strictEqual(actual, expected);
+    },
+    toBeTruthy() {
+      assert.ok(actual);
+    },
+    toContainEqual(expected) {
+      assert.ok(actual.some((item) => {
+        try {
+          assert.deepStrictEqual(item, expected);
+          return true;
+        } catch (err) {
+          return false;
+        }
+      }), 'Expected array to contain provided value');
+    },
+    toBeGreaterThan(number) {
+      assert.ok(actual > number, `${actual} is not greater than ${number}`);
+    },
+    toBeLessThan(number) {
+      assert.ok(actual < number, `${actual} is not less than ${number}`);
+    },
+  };
+}
+
+async function runSuite(suite, ancestors = { beforeEach: [], afterEach: [] }, depth = 0) {
+  const beforeEachHooks = [...ancestors.beforeEach, ...suite.beforeEach];
+  const afterEachHooks = [...suite.afterEach, ...ancestors.afterEach];
+  let failures = 0;
+
+  for (const test of suite.tests) {
+    for (const hook of beforeEachHooks) {
+      await hook();
+    }
+    try {
+      await test.fn();
+      console.log(`${'  '.repeat(depth)}✓ ${test.name}`);
+    } catch (err) {
+      failures += 1;
+      console.error(`${'  '.repeat(depth)}✗ ${test.name}`);
+      console.error(`${'  '.repeat(depth + 1)}${err.message}`);
+    }
+    for (const hook of afterEachHooks) {
+      await hook();
+    }
+  }
+
+  for (const child of suite.suites) {
+    console.log(`${'  '.repeat(depth)}${child.name}`);
+    failures += await runSuite(child, { beforeEach: beforeEachHooks, afterEach: afterEachHooks }, depth + 1);
+  }
+
+  return failures;
+}
+
+async function run() {
+  let failures = 0;
+  for (const suite of rootSuite.suites) {
+    console.log(suite.name);
+    failures += await runSuite(suite, { beforeEach: [], afterEach: [] }, 1);
+  }
+  if (failures > 0) {
+    console.error(`\n${failures} test(s) failed.`);
+  } else {
+    console.log('\nAll tests passed');
+  }
+  return failures;
+}
+
+module.exports = {
+  describe,
+  it,
+  beforeEach,
+  afterEach,
+  expect,
+  run,
+};

--- a/backend/tests/mq.test.js
+++ b/backend/tests/mq.test.js
@@ -1,0 +1,64 @@
+const { describe, it, expect, beforeEach } = require('./jest-lite');
+const AuditEngine = require('../services/auditEngine');
+const EventBus = require('../mq/eventBus');
+const IIAService = require('../services/iia');
+
+function createAuditRepository() {
+  const store = new Map();
+  return {
+    async getAllAudits() {
+      return Array.from(store.values());
+    },
+    async getAuditById(id) {
+      return store.get(id) || null;
+    },
+    async createAudit(audit) {
+      store.set(audit.id, audit);
+      return audit;
+    },
+    async updateAudit(audit) {
+      store.set(audit.id, audit);
+      return audit;
+    },
+  };
+}
+
+describe('Message queue publishing', () => {
+  let eventBus;
+  let auditEngine;
+
+  beforeEach(() => {
+    const riskId = '11111111-1111-1111-1111-111111111111';
+    eventBus = new EventBus();
+    const auditRepository = createAuditRepository();
+    const riskEngine = { listRisks: async () => [{ id: riskId }, { id: '22222222-2222-2222-2222-222222222222' }] };
+    const coreIntegration = { notifyAudit: async () => ({}) };
+    auditEngine = new AuditEngine({
+      auditRepository,
+      riskEngine,
+      eventBus,
+      coreIntegration,
+      iia: new IIAService(),
+    });
+    auditEngine.__testRiskId = riskId;
+  });
+
+  it('publishes audit_planned events', async () => {
+    let receivedPayload = null;
+    eventBus.subscribe('audit_planned', (payload) => {
+      receivedPayload = payload;
+    });
+
+    const audit = await auditEngine.planAudit({
+      title: 'Annual SOX Review',
+      objective: 'Evaluate key controls',
+      leadAuditor: 'Lead',
+      riskIds: [auditEngine.__testRiskId],
+    });
+
+    expect(audit.coverage).toBeGreaterThan(0);
+    const published = eventBus.published.filter((event) => event.event === 'audit_planned');
+    expect(published.length).toBeGreaterThan(0);
+    expect(receivedPayload.id).toBe(audit.id);
+  });
+});

--- a/backend/tests/riskEngine.test.js
+++ b/backend/tests/riskEngine.test.js
@@ -1,0 +1,67 @@
+const { describe, it, expect, beforeEach } = require('./jest-lite');
+const RiskEngine = require('../services/riskEngine');
+const COSOService = require('../services/coso');
+const EventBus = require('../mq/eventBus');
+
+function createRepository() {
+  const store = new Map();
+  return {
+    async getAllRisks() {
+      return Array.from(store.values());
+    },
+    async getRiskById(id) {
+      return store.get(id) || null;
+    },
+    async createRisk(risk) {
+      store.set(risk.id, risk);
+      return risk;
+    },
+    async updateRisk(risk) {
+      store.set(risk.id, risk);
+      return risk;
+    },
+  };
+}
+
+describe('RiskEngine', () => {
+  let repository;
+  let eventBus;
+  let riskEngine;
+
+  beforeEach(() => {
+    repository = createRepository();
+    eventBus = new EventBus();
+    const coso = new COSOService();
+    const coreIntegration = { syncRisk: async () => ({}) };
+    riskEngine = new RiskEngine({ riskRepository: repository, eventBus, coreIntegration, coso });
+  });
+
+  it('calculates residual score when creating risks', async () => {
+    const risk = await riskEngine.createRisk({
+      title: 'Vendor Reliability',
+      description: 'Assess third-party uptime risk',
+      owner: 'Risk Manager',
+      inherentImpact: 4,
+      inherentLikelihood: 4,
+      controls: [
+        { name: 'Vendor assessment', owner: 'Procurement', status: 'effective' },
+      ],
+    });
+
+    expect(risk.residualScore).toBe(15);
+  });
+
+  it('publishes an event when updating a risk', async () => {
+    const risk = await riskEngine.createRisk({
+      title: 'Cybersecurity',
+      description: 'Threat of ransomware attack',
+      owner: 'CISO',
+    });
+
+    await riskEngine.updateRisk(risk.id, { status: 'mitigated' });
+
+    const updates = eventBus.published.filter((event) => event.event === 'risk_updated');
+    expect(updates.length).toBeGreaterThan(0);
+    expect(updates[0].payload.id).toBe(risk.id);
+  });
+});

--- a/backend/tests/run.js
+++ b/backend/tests/run.js
@@ -1,0 +1,9 @@
+const runner = require('./jest-lite');
+
+require('./api.test');
+require('./riskEngine.test');
+require('./mq.test');
+
+runner.run().then((failures) => {
+  process.exitCode = failures > 0 ? 1 : 0;
+});


### PR DESCRIPTION
## Summary
- implement a lightweight Express-style backend with auth, risk, audit, and report APIs plus an OpenAPI document
- add domain models, repositories, caching, and business services wired to an event bus for GRC workflows
- build a custom Jest-like test harness exercising API flows, engines, and message publishing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cdbb65fd088328b54a1e791519e267