### PR TITLE
Implement integrated RM and IA phase one services

### DIFF
--- a/backend/api/audit.js
+++ b/backend/api/audit.js
@@ -12,6 +12,44 @@ function createAuditRouter({ auditEngine, feedbackService }) {
     }
   });
 
+  router.get('/timesheets', async (req, res, next) => {
+    try {
+      const { auditor } = req.query;
+      const entries = await auditEngine.listTimesheets({ auditor });
+      res.json(entries);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post('/timesheets', async (req, res, next) => {
+    try {
+      const entry = await auditEngine.recordTimesheet(req.body);
+      res.status(201).json(entry);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/working-papers', async (req, res, next) => {
+    try {
+      const { auditId } = req.query;
+      const papers = await auditEngine.listWorkingPapers({ auditId });
+      res.json(papers);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.patch('/working-papers/:id', async (req, res, next) => {
+    try {
+      const updated = await auditEngine.updateWorkingPaper(req.params.id, req.body);
+      res.json(updated);
+    } catch (error) {
+      next(error);
+    }
+  });
+
   router.post('/', async (req, res, next) => {
     try {
       const created = await auditEngine.planAudit(req.body);
@@ -22,6 +60,15 @@ function createAuditRouter({ auditEngine, feedbackService }) {
   });
 
   router.put('/:id', async (req, res, next) => {
+    try {
+      const updated = await auditEngine.updateAudit(req.params.id, req.body);
+      res.json(updated);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.patch('/:id', async (req, res, next) => {
     try {
       const updated = await auditEngine.updateAudit(req.params.id, req.body);
       res.json(updated);

--- a/backend/api/auth.js
+++ b/backend/api/auth.js
@@ -5,8 +5,8 @@ function createAuthRouter({ authService }) {
 
   router.post('/login', async (req, res, next) => {
     try {
-      const token = await authService.login(req.body);
-      res.status(200).json(token);
+      const response = await authService.login(req.body);
+      res.status(200).json(response);
     } catch (error) {
       next(error);
     }
@@ -19,6 +19,25 @@ function createAuthRouter({ authService }) {
       res.status(200).json(refreshed);
     } catch (error) {
       error.status = 401;
+      next(error);
+    }
+  });
+
+  router.get('/me', async (req, res, next) => {
+    try {
+      const authHeader = req.headers.authorization || '';
+      const token = authHeader.startsWith('Bearer ')
+        ? authHeader.slice(7)
+        : authHeader;
+      if (!token) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+      const user = await authService.getCurrentUser(token);
+      if (!user) {
+        return res.status(401).json({ error: 'Unauthorized' });
+      }
+      res.status(200).json(user);
+    } catch (error) {
       next(error);
     }
   });

--- a/backend/api/report.js
+++ b/backend/api/report.js
@@ -5,17 +5,9 @@ function createReportRouter({ reportService, coreIntegration }) {
 
   router.get('/', async (req, res, next) => {
     try {
-      const reports = await reportService.listReports();
+      const { status, owner } = req.query;
+      const reports = await reportService.listReports({ status, owner });
       res.json(reports);
-    } catch (error) {
-      next(error);
-    }
-  });
-
-  router.post('/', async (req, res, next) => {
-    try {
-      const stored = await reportService.generateAndStoreReport();
-      res.status(201).json(stored);
     } catch (error) {
       next(error);
     }
@@ -25,6 +17,27 @@ function createReportRouter({ reportService, coreIntegration }) {
     try {
       const summary = await coreIntegration.generateRiskReport();
       res.json(summary);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/:id', async (req, res, next) => {
+    try {
+      const report = await reportService.getReport(req.params.id);
+      if (!report) {
+        return res.status(404).json({ error: 'Report not found' });
+      }
+      res.json(report);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post('/:id/generate', async (req, res, next) => {
+    try {
+      const result = await reportService.generateReport(req.params.id);
+      res.status(201).json(result);
     } catch (error) {
       next(error);
     }

--- a/backend/api/risk.js
+++ b/backend/api/risk.js
@@ -5,8 +5,28 @@ function createRiskRouter({ riskEngine }) {
 
   router.get('/', async (req, res, next) => {
     try {
-      const risks = await riskEngine.listRisks();
+      const { status, owner } = req.query;
+      const risks = await riskEngine.listRisks({ status, owner });
       res.json(risks);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/summary', async (req, res, next) => {
+    try {
+      const summary = await riskEngine.getSummary();
+      res.json(summary);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.get('/follow-ups', async (req, res, next) => {
+    try {
+      const { riskId } = req.query;
+      const followUps = await riskEngine.listFollowUps({ riskId });
+      res.json(followUps);
     } catch (error) {
       next(error);
     }
@@ -25,6 +45,24 @@ function createRiskRouter({ riskEngine }) {
     try {
       const updated = await riskEngine.updateRisk(req.params.id, req.body);
       res.json(updated);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.patch('/:id', async (req, res, next) => {
+    try {
+      const updated = await riskEngine.updateRisk(req.params.id, req.body);
+      res.json(updated);
+    } catch (error) {
+      next(error);
+    }
+  });
+
+  router.post('/:id/questionnaire', async (req, res, next) => {
+    try {
+      const result = await riskEngine.submitQuestionnaire(req.params.id, req.body);
+      res.status(201).json(result);
     } catch (error) {
       next(error);
     }

--- a/backend/container.js
+++ b/backend/container.js
@@ -3,6 +3,9 @@ const { createRedis } = require('./config/cache');
 const RiskRepository = require('./repositories/RiskRepository');
 const AuditRepository = require('./repositories/AuditRepository');
 const ReportRepository = require('./repositories/ReportRepository');
+const TimesheetRepository = require('./repositories/TimesheetRepository');
+const WorkingPaperRepository = require('./repositories/WorkingPaperRepository');
+const FollowUpRepository = require('./repositories/FollowUpRepository');
 const RiskEngine = require('./services/RiskEngine');
 const AuditEngine = require('./services/AuditEngine');
 const FeedbackService = require('./services/Feedback');
@@ -19,9 +22,15 @@ function buildContainer(overrides = {}) {
   const riskRepository = overrides.riskRepository || new RiskRepository({ pool, cache });
   const auditRepository = overrides.auditRepository || new AuditRepository({ pool, cache });
   const reportRepository = overrides.reportRepository || new ReportRepository({ pool, cache });
+  const timesheetRepository = overrides.timesheetRepository || new TimesheetRepository({ pool });
+  const workingPaperRepository =
+    overrides.workingPaperRepository || new WorkingPaperRepository({ pool });
+  const followUpRepository = overrides.followUpRepository || new FollowUpRepository({ pool });
 
-  const riskEngine = overrides.riskEngine || new RiskEngine({ riskRepository });
-  const auditEngine = overrides.auditEngine || new AuditEngine({ auditRepository });
+  const riskEngine = overrides.riskEngine || new RiskEngine({ riskRepository, followUpRepository });
+  const auditEngine =
+    overrides.auditEngine ||
+    new AuditEngine({ auditRepository, timesheetRepository, workingPaperRepository });
   const feedbackService = overrides.feedbackService || new FeedbackService({ auditRepository });
 
   const coreIntegration =
@@ -38,6 +47,9 @@ function buildContainer(overrides = {}) {
     riskRepository,
     auditRepository,
     reportRepository,
+    timesheetRepository,
+    workingPaperRepository,
+    followUpRepository,
     riskEngine,
     auditEngine,
     feedbackService,

--- a/backend/domain/auditEngagement.js
+++ b/backend/domain/auditEngagement.js
@@ -1,16 +1,50 @@
 const { z } = require('zod');
-const { FindingSchema } = require('./finding');
 
-const AuditEngagementSchema = z.object({
-  id: z.string().uuid().optional(),
-  name: z.string().min(1),
-  scope: z.string().min(1),
-  status: z.enum(['draft', 'planned', 'in_progress', 'completed']).default('draft'),
-  findings: z.array(FindingSchema).default([])
+const statusEnum = z.enum(['planned', 'in-progress', 'complete']);
+
+const dateSchema = z.string().refine((value) => !Number.isNaN(Date.parse(value)), {
+  message: 'Invalid date format'
 });
 
+const AuditEngagementSchema = z
+  .object({
+    id: z.union([z.string(), z.number()]).transform((value) => value.toString()).optional(),
+    title: z.string().min(1),
+    owner: z.string().min(1),
+    startDate: dateSchema,
+    endDate: dateSchema,
+    status: statusEnum.default('planned'),
+    scope: z.string().optional(),
+    description: z.string().optional()
+  })
+  .refine((value) => new Date(value.endDate) >= new Date(value.startDate), {
+    message: 'End date must be after the start date',
+    path: ['endDate']
+  });
+
+const AuditEngagementUpdateSchema = AuditEngagementSchema.pick({
+  owner: true,
+  startDate: true,
+  endDate: true,
+  status: true,
+  scope: true,
+  description: true,
+  title: true
+})
+  .partial()
+  .refine((value) => {
+    if (!value.startDate || !value.endDate) {
+      return true;
+    }
+    return new Date(value.endDate) >= new Date(value.startDate);
+  }, {
+    message: 'End date must be after the start date',
+    path: ['endDate']
+  });
+
 function createAuditEngagement(input) {
-  return AuditEngagementSchema.parse(input);
+  const parsed = AuditEngagementSchema.parse(input);
+  return parsed;
 }
 
-module.exports = { AuditEngagementSchema, createAuditEngagement };
+module.exports = { AuditEngagementSchema, AuditEngagementUpdateSchema, createAuditEngagement };

--- a/backend/domain/followUp.js
+++ b/backend/domain/followUp.js
@@ -1,0 +1,18 @@
+const { z } = require('zod');
+
+const FollowUpSchema = z.object({
+  id: z.union([z.string(), z.number()]).transform((value) => value.toString()).optional(),
+  riskId: z.union([z.string(), z.number()]).transform((value) => value.toString()),
+  action: z.string().min(1),
+  owner: z.string().min(1),
+  dueDate: z.string().refine((value) => !Number.isNaN(Date.parse(value)), {
+    message: 'Invalid due date'
+  }),
+  status: z.enum(['pending', 'in-progress', 'complete'])
+});
+
+const FollowUpFilterSchema = z.object({
+  riskId: z.string().optional()
+});
+
+module.exports = { FollowUpFilterSchema, FollowUpSchema };

--- a/backend/domain/report.js
+++ b/backend/domain/report.js
@@ -1,0 +1,22 @@
+const { z } = require('zod');
+
+const reportStatusEnum = z.enum(['draft', 'issued']);
+
+const ReportSchema = z.object({
+  id: z.union([z.string(), z.number()]).transform((value) => value.toString()).optional(),
+  title: z.string().min(1),
+  owner: z.string().min(1),
+  status: reportStatusEnum.default('draft'),
+  issuedDate: z.string().optional()
+});
+
+const ReportFiltersSchema = z.object({
+  status: reportStatusEnum.optional(),
+  owner: z.string().optional()
+});
+
+module.exports = {
+  ReportFiltersSchema,
+  ReportSchema,
+  reportStatusEnum
+};

--- a/backend/domain/risk.js
+++ b/backend/domain/risk.js
@@ -1,17 +1,91 @@
 const { z } = require('zod');
-const { ControlSchema } = require('./control');
 
-const RiskSchema = z.object({
-  id: z.string().uuid().optional(),
+const riskStatusEnum = z.enum(['open', 'mitigated', 'closed']);
+
+const scoreSchema = z.preprocess((value) => {
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return value;
+}, z.number().min(1).max(25));
+
+const dateSchema = z
+  .string()
+  .optional()
+  .refine((value) => !value || !Number.isNaN(Date.parse(value)), {
+    message: 'Invalid date value'
+  });
+
+const RiskInputSchema = z.object({
   title: z.string().min(1),
-  description: z.string().min(1),
   category: z.string().min(1),
-  severity: z.enum(['low', 'medium', 'high']),
-  controls: z.array(ControlSchema).default([])
+  owner: z.string().min(1),
+  inherentRisk: scoreSchema,
+  residualRisk: scoreSchema.optional(),
+  status: riskStatusEnum.default('open'),
+  description: z.string().optional(),
+  appetite: scoreSchema.optional(),
+  reportedOn: dateSchema
+});
+
+const RiskUpdateSchema = RiskInputSchema.partial();
+
+const QuestionnaireResponsesSchema = z.object({
+  owner: z.string().min(1),
+  riskCategory: z.string().min(1),
+  likelihood: scoreSchema,
+  impact: scoreSchema,
+  description: z.string().min(1),
+  controls: z.string().optional()
+});
+
+const RiskQuestionnaireSchema = z.object({
+  riskId: z.string().optional(),
+  responses: QuestionnaireResponsesSchema
+});
+
+const RiskFiltersSchema = z.object({
+  status: riskStatusEnum.optional(),
+  owner: z.string().optional()
 });
 
 function createRisk(input) {
-  return RiskSchema.parse(input);
+  const parsed = RiskInputSchema.parse(input);
+  return {
+    ...parsed,
+    residualRisk: parsed.residualRisk ?? parsed.inherentRisk
+  };
 }
 
-module.exports = { RiskSchema, createRisk };
+function updateRisk(input) {
+  return RiskUpdateSchema.parse(input);
+}
+
+function createRiskFromQuestionnaire(input) {
+  const { responses } = RiskQuestionnaireSchema.parse(input);
+  const inherentRisk = Number(responses.likelihood) * Number(responses.impact);
+  const title = `${responses.riskCategory} risk - ${responses.owner}`;
+  return {
+    title,
+    category: responses.riskCategory,
+    owner: responses.owner,
+    inherentRisk,
+    residualRisk: inherentRisk,
+    status: 'open',
+    description: responses.description
+  };
+}
+
+module.exports = {
+  riskStatusEnum,
+  RiskFiltersSchema,
+  RiskInputSchema,
+  RiskQuestionnaireSchema,
+  RiskUpdateSchema,
+  createRisk,
+  createRiskFromQuestionnaire,
+  updateRisk
+};

--- a/backend/domain/timesheet.js
+++ b/backend/domain/timesheet.js
@@ -1,0 +1,34 @@
+const { z } = require('zod');
+
+const numericSchema = z.preprocess((value) => {
+  if (typeof value === 'string' && value.trim() !== '') {
+    const parsed = Number(value);
+    if (!Number.isNaN(parsed)) {
+      return parsed;
+    }
+  }
+  return value;
+}, z.number().min(0));
+
+const dateSchema = z.string().refine((value) => !Number.isNaN(Date.parse(value)), {
+  message: 'Invalid date value'
+});
+
+const TimesheetSchema = z.object({
+  id: z.union([z.string(), z.number()]).transform((value) => value.toString()).optional(),
+  auditor: z.string().min(1),
+  date: dateSchema,
+  hours: numericSchema,
+  engagement: z.string().min(1),
+  description: z.string().optional()
+});
+
+const TimesheetFilterSchema = z.object({
+  auditor: z.string().optional()
+});
+
+function createTimesheet(input) {
+  return TimesheetSchema.parse(input);
+}
+
+module.exports = { TimesheetFilterSchema, TimesheetSchema, createTimesheet };

--- a/backend/domain/workingPaper.js
+++ b/backend/domain/workingPaper.js
@@ -1,0 +1,22 @@
+const { z } = require('zod');
+
+const WorkingPaperSchema = z.object({
+  id: z.union([z.string(), z.number()]).transform((value) => value.toString()).optional(),
+  auditId: z.union([z.string(), z.number()]).transform((value) => value.toString()),
+  name: z.string().min(1),
+  owner: z.string().min(1),
+  status: z.enum(['draft', 'review', 'approved']),
+  updatedAt: z.string().optional()
+});
+
+const WorkingPaperUpdateSchema = WorkingPaperSchema.pick({ status: true });
+
+const WorkingPaperFilterSchema = z.object({
+  auditId: z.string().optional()
+});
+
+module.exports = {
+  WorkingPaperFilterSchema,
+  WorkingPaperSchema,
+  WorkingPaperUpdateSchema
+};

--- a/backend/openapi.js
+++ b/backend/openapi.js
@@ -1,61 +1,90 @@
 const riskSchema = {
   type: 'object',
   properties: {
-    id: { type: 'string', format: 'uuid' },
+    id: { type: 'string' },
     title: { type: 'string' },
-    description: { type: 'string' },
     category: { type: 'string' },
-    severity: { type: 'string', enum: ['low', 'medium', 'high'] },
-    controls: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          id: { type: 'string', format: 'uuid' },
-          name: { type: 'string' },
-          description: { type: 'string' },
-          owner: { type: 'string' }
-        },
-        required: ['name', 'description', 'owner']
-      }
-    }
+    inherentRisk: { type: 'number' },
+    residualRisk: { type: 'number' },
+    owner: { type: 'string' },
+    status: { type: 'string', enum: ['open', 'mitigated', 'closed'] }
   },
-  required: ['title', 'description', 'category', 'severity']
+  required: ['title', 'category', 'inherentRisk', 'residualRisk', 'owner', 'status']
+};
+
+const followUpSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    riskId: { type: 'string' },
+    action: { type: 'string' },
+    owner: { type: 'string' },
+    dueDate: { type: 'string', format: 'date' },
+    status: { type: 'string', enum: ['pending', 'in-progress', 'complete'] }
+  },
+  required: ['riskId', 'action', 'owner', 'dueDate', 'status']
 };
 
 const auditSchema = {
   type: 'object',
   properties: {
-    id: { type: 'string', format: 'uuid' },
-    name: { type: 'string' },
-    scope: { type: 'string' },
-    status: { type: 'string', enum: ['draft', 'planned', 'in_progress', 'completed'] },
-    findings: {
-      type: 'array',
-      items: {
-        type: 'object',
-        properties: {
-          id: { type: 'string', format: 'uuid' },
-          title: { type: 'string' },
-          description: { type: 'string' },
-          severity: { type: 'string', enum: ['low', 'medium', 'high'] },
-          remediation: { type: 'string' },
-          status: { type: 'string', enum: ['open', 'in_progress', 'closed'] }
-        },
-        required: ['title', 'description', 'severity']
-      }
-    }
+    id: { type: 'string' },
+    title: { type: 'string' },
+    owner: { type: 'string' },
+    startDate: { type: 'string', format: 'date' },
+    endDate: { type: 'string', format: 'date' },
+    status: { type: 'string', enum: ['planned', 'in-progress', 'complete'] },
+    scope: { type: 'string' }
   },
-  required: ['name', 'scope']
+  required: ['title', 'owner', 'startDate', 'endDate', 'status']
+};
+
+const timesheetSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    auditor: { type: 'string' },
+    date: { type: 'string', format: 'date' },
+    hours: { type: 'number' },
+    engagement: { type: 'string' }
+  },
+  required: ['auditor', 'date', 'hours', 'engagement']
+};
+
+const workingPaperSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    auditId: { type: 'string' },
+    name: { type: 'string' },
+    owner: { type: 'string' },
+    status: { type: 'string', enum: ['draft', 'review', 'approved'] },
+    updatedAt: { type: 'string', format: 'date-time' }
+  },
+  required: ['auditId', 'name', 'owner', 'status']
 };
 
 const reportSchema = {
   type: 'object',
   properties: {
-    id: { type: 'string', format: 'uuid' },
-    content: { type: 'string' },
-    created_at: { type: 'string', format: 'date-time' }
-  }
+    id: { type: 'string' },
+    title: { type: 'string' },
+    owner: { type: 'string' },
+    status: { type: 'string', enum: ['draft', 'issued'] },
+    issuedDate: { type: 'string', format: 'date' }
+  },
+  required: ['title', 'owner', 'status']
+};
+
+const userSchema = {
+  type: 'object',
+  properties: {
+    id: { type: 'string' },
+    name: { type: 'string' },
+    email: { type: 'string', format: 'email' },
+    role: { type: 'string', enum: ['admin', 'auditor', 'manager'] }
+  },
+  required: ['id', 'name', 'email', 'role']
 };
 
 const swaggerDefinition = {
@@ -75,22 +104,25 @@ const swaggerDefinition = {
               schema: {
                 type: 'object',
                 properties: {
-                  username: { type: 'string' },
+                  email: { type: 'string', format: 'email' },
                   password: { type: 'string' }
                 },
-                required: ['username', 'password']
+                required: ['email', 'password']
               }
             }
           }
         },
         responses: {
           200: {
-            description: 'JWT token',
+            description: 'Authenticated session',
             content: {
               'application/json': {
                 schema: {
                   type: 'object',
-                  properties: { token: { type: 'string' } }
+                  properties: {
+                    token: { type: 'string' },
+                    user: userSchema
+                  }
                 }
               }
             }
@@ -100,7 +132,7 @@ const swaggerDefinition = {
     },
     '/auth/refresh': {
       post: {
-        summary: 'Refresh a token',
+        summary: 'Refresh an authentication token',
         requestBody: {
           required: true,
           content: {
@@ -120,7 +152,10 @@ const swaggerDefinition = {
               'application/json': {
                 schema: {
                   type: 'object',
-                  properties: { token: { type: 'string' } }
+                  properties: {
+                    token: { type: 'string' },
+                    user: userSchema
+                  }
                 }
               }
             }
@@ -128,37 +163,92 @@ const swaggerDefinition = {
         }
       }
     },
+    '/auth/me': {
+      get: {
+        summary: 'Retrieve the currently authenticated user',
+        responses: {
+          200: {
+            description: 'User information',
+            content: {
+              'application/json': {
+                schema: userSchema
+              }
+            }
+          },
+          401: {
+            description: 'Not authenticated'
+          }
+        }
+      }
+    },
     '/risks': {
       get: {
-        summary: 'List risks',
+        summary: 'List risks with optional filters',
+        parameters: [
+          { name: 'status', in: 'query', schema: { type: 'string' } },
+          { name: 'owner', in: 'query', schema: { type: 'string' } }
+        ],
         responses: {
           200: {
             description: 'List of risks',
+            content: { 'application/json': { schema: { type: 'array', items: riskSchema } } }
+          }
+        }
+      },
+      post: {
+        summary: 'Create a risk entry',
+        requestBody: {
+          required: true,
+          content: { 'application/json': { schema: riskSchema } }
+        },
+        responses: {
+          201: { description: 'Risk created', content: { 'application/json': { schema: riskSchema } } }
+        }
+      }
+    },
+    '/risks/summary': {
+      get: {
+        summary: 'Risk exposure summary',
+        responses: {
+          200: {
+            description: 'Aggregated metrics',
             content: {
               'application/json': {
                 schema: {
-                  type: 'array',
-                  items: riskSchema
+                  type: 'object',
+                  properties: {
+                    totalRisks: { type: 'integer' },
+                    highRisks: { type: 'integer' },
+                    mediumRisks: { type: 'integer' },
+                    lowRisks: { type: 'integer' },
+                    trend: {
+                      type: 'array',
+                      items: {
+                        type: 'object',
+                        properties: {
+                          month: { type: 'string' },
+                          high: { type: 'integer' },
+                          medium: { type: 'integer' },
+                          low: { type: 'integer' }
+                        }
+                      }
+                    }
+                  }
                 }
               }
             }
           }
         }
-      },
-      post: {
-        summary: 'Create a risk',
-        requestBody: {
-          required: true,
-          content: {
-            'application/json': { schema: riskSchema }
-          }
-        },
+      }
+    },
+    '/risks/follow-ups': {
+      get: {
+        summary: 'List follow-up actions by risk',
+        parameters: [{ name: 'riskId', in: 'query', schema: { type: 'string' } }],
         responses: {
-          201: {
-            description: 'Risk created',
-            content: {
-              'application/json': { schema: riskSchema }
-            }
+          200: {
+            description: 'Follow-up actions',
+            content: { 'application/json': { schema: { type: 'array', items: followUpSchema } } }
           }
         }
       }
@@ -166,93 +256,145 @@ const swaggerDefinition = {
     '/risks/{id}': {
       put: {
         summary: 'Update a risk',
-        parameters: [
-          {
-            name: 'id',
-            in: 'path',
-            required: true,
-            schema: { type: 'string' }
-          }
-        ],
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        requestBody: {
+          required: true,
+          content: { 'application/json': { schema: riskSchema } }
+        },
+        responses: { 200: { description: 'Risk updated', content: { 'application/json': { schema: riskSchema } } } }
+      },
+      patch: {
+        summary: 'Partially update a risk',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        requestBody: {
+          required: true,
+          content: { 'application/json': { schema: { ...riskSchema, required: [] } } }
+        },
+        responses: { 200: { description: 'Risk updated', content: { 'application/json': { schema: riskSchema } } } }
+      }
+    },
+    '/risks/{id}/questionnaire': {
+      post: {
+        summary: 'Submit a risk identification questionnaire',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
         requestBody: {
           required: true,
           content: {
-            'application/json': { schema: { ...riskSchema, required: [] } }
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: {
+                  riskId: { type: 'string' },
+                  responses: {
+                    type: 'object',
+                    properties: {
+                      owner: { type: 'string' },
+                      riskCategory: { type: 'string' },
+                      likelihood: { type: 'string' },
+                      impact: { type: 'string' },
+                      description: { type: 'string' },
+                      controls: { type: 'string' }
+                    }
+                  }
+                },
+                required: ['responses']
+              }
+            }
           }
         },
         responses: {
-          200: {
-            description: 'Risk updated',
-            content: {
-              'application/json': { schema: riskSchema }
-            }
-          }
+          201: { description: 'Risk intake recorded', content: { 'application/json': { schema: riskSchema } } }
         }
       }
     },
     '/audits': {
       get: {
-        summary: 'List audits',
+        summary: 'List audit engagements',
         responses: {
-          200: {
-            description: 'List of audits',
-            content: {
-              'application/json': {
-                schema: {
-                  type: 'array',
-                  items: auditSchema
-                }
-              }
-            }
-          }
+          200: { description: 'Audits', content: { 'application/json': { schema: { type: 'array', items: auditSchema } } } }
         }
       },
       post: {
-        summary: 'Plan an audit',
-        requestBody: {
-          required: true,
-          content: {
-            'application/json': { schema: auditSchema }
-          }
-        },
+        summary: 'Create an audit engagement',
+        requestBody: { required: true, content: { 'application/json': { schema: auditSchema } } },
         responses: {
-          201: {
-            description: 'Audit created',
-            content: {
-              'application/json': { schema: auditSchema }
-            }
-          }
+          201: { description: 'Audit created', content: { 'application/json': { schema: auditSchema } } }
         }
       }
     },
     '/audits/{id}': {
       put: {
-        summary: 'Update an audit',
-        parameters: [
-          { name: 'id', in: 'path', required: true, schema: { type: 'string' } }
-        ],
+        summary: 'Update an audit engagement',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        requestBody: { required: true, content: { 'application/json': { schema: { ...auditSchema, required: [] } } } },
+        responses: { 200: { description: 'Audit updated', content: { 'application/json': { schema: auditSchema } } } }
+      },
+      patch: {
+        summary: 'Partially update an audit engagement',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        requestBody: { required: true, content: { 'application/json': { schema: { ...auditSchema, required: [] } } } },
+        responses: { 200: { description: 'Audit updated', content: { 'application/json': { schema: auditSchema } } } }
+      }
+    },
+    '/audits/timesheets': {
+      get: {
+        summary: 'List timesheet entries',
+        parameters: [{ name: 'auditor', in: 'query', schema: { type: 'string' } }],
+        responses: {
+          200: {
+            description: 'Timesheet entries',
+            content: { 'application/json': { schema: { type: 'array', items: timesheetSchema } } }
+          }
+        }
+      },
+      post: {
+        summary: 'Create a timesheet entry',
+        requestBody: { required: true, content: { 'application/json': { schema: timesheetSchema } } },
+        responses: {
+          201: {
+            description: 'Timesheet recorded',
+            content: { 'application/json': { schema: timesheetSchema } }
+          }
+        }
+      }
+    },
+    '/audits/working-papers': {
+      get: {
+        summary: 'List working papers',
+        parameters: [{ name: 'auditId', in: 'query', schema: { type: 'string' } }],
+        responses: {
+          200: {
+            description: 'Working papers',
+            content: { 'application/json': { schema: { type: 'array', items: workingPaperSchema } } }
+          }
+        }
+      }
+    },
+    '/audits/working-papers/{id}': {
+      patch: {
+        summary: 'Update working paper status',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
         requestBody: {
           required: true,
           content: {
-            'application/json': { schema: { ...auditSchema, required: [] } }
+            'application/json': {
+              schema: {
+                type: 'object',
+                properties: { status: { type: 'string', enum: ['draft', 'review', 'approved'] } },
+                required: ['status']
+              }
+            }
           }
         },
         responses: {
-          200: {
-            description: 'Audit updated',
-            content: {
-              'application/json': { schema: auditSchema }
-            }
-          }
+          200: { description: 'Working paper updated', content: { 'application/json': { schema: workingPaperSchema } } }
         }
       }
     },
     '/audits/{id}/feedback': {
       post: {
         summary: 'Submit audit feedback',
-        parameters: [
-          { name: 'id', in: 'path', required: true, schema: { type: 'string' } }
-        ],
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
         requestBody: {
           required: true,
           content: {
@@ -270,7 +412,7 @@ const swaggerDefinition = {
         },
         responses: {
           201: {
-            description: 'Feedback captured',
+            description: 'Feedback recorded',
             content: {
               'application/json': {
                 schema: {
@@ -290,43 +432,71 @@ const swaggerDefinition = {
     '/reports': {
       get: {
         summary: 'List reports',
+        parameters: [
+          { name: 'status', in: 'query', schema: { type: 'string' } },
+          { name: 'owner', in: 'query', schema: { type: 'string' } }
+        ],
         responses: {
           200: {
-            description: 'List of reports',
-            content: {
-              'application/json': {
-                schema: { type: 'array', items: reportSchema }
-              }
-            }
+            description: 'Reports',
+            content: { 'application/json': { schema: { type: 'array', items: reportSchema } } }
           }
         }
-      },
+      }
+    },
+    '/reports/{id}': {
+      get: {
+        summary: 'Get report details',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
+        responses: {
+          200: { description: 'Report details', content: { 'application/json': { schema: reportSchema } } },
+          404: { description: 'Report not found' }
+        }
+      }
+    },
+    '/reports/{id}/generate': {
       post: {
-        summary: 'Generate a summary report',
+        summary: 'Generate a report based on current risk and audit data',
+        parameters: [{ name: 'id', in: 'path', required: true, schema: { type: 'string' } }],
         responses: {
           201: {
             description: 'Report generated',
-            content: {
-              'application/json': { schema: reportSchema }
-            }
+            content: { 'application/json': { schema: reportSchema } }
           }
         }
       }
     },
     '/reports/summary': {
       get: {
-        summary: 'Get aggregated risk/audit summary',
+        summary: 'Retrieve the latest aggregate summary',
         responses: {
           200: {
-            description: 'Summary snapshot',
+            description: 'Aggregated report snapshot',
             content: {
               'application/json': {
                 schema: {
                   type: 'object',
                   properties: {
-                    totalRisks: { type: 'integer' },
-                    highSeverityRisks: { type: 'integer' },
-                    plannedAudits: { type: 'integer' }
+                    generatedAt: { type: 'string', format: 'date-time' },
+                    riskSummary: {
+                      type: 'object',
+                      properties: {
+                        totalRisks: { type: 'integer' },
+                        highRisks: { type: 'integer' },
+                        mediumRisks: { type: 'integer' },
+                        lowRisks: { type: 'integer' }
+                      }
+                    },
+                    auditOverview: {
+                      type: 'object',
+                      properties: {
+                        total: { type: 'integer' },
+                        byStatus: {
+                          type: 'object',
+                          additionalProperties: { type: 'integer' }
+                        }
+                      }
+                    }
                   }
                 }
               }

--- a/backend/repositories/AuditRepository.js
+++ b/backend/repositories/AuditRepository.js
@@ -5,20 +5,102 @@ class AuditRepository extends BaseRepository {
     super({ pool, cache, table: 'audits' });
   }
 
-  async findPlannedAudits() {
-    const cacheKey = 'audits:planned';
+  async findAll(filters = {}) {
+    const conditions = [];
+    const values = [];
+    if (filters.status) {
+      values.push(filters.status);
+      conditions.push(`status = $${values.length}`);
+    }
+    const whereClause = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+    const sql = `
+      SELECT id, code, title, owner, start_date, end_date, status, scope
+      FROM audits
+      ${whereClause}
+      ORDER BY start_date NULLS LAST, created_at DESC
+    `;
+    const { rows } = await this.pool.query(sql, values);
+    return rows;
+  }
+
+  async createPlan(plan) {
+    const now = new Date();
+    const code = plan.code || `AUD-${now.getUTCFullYear()}${String(now.getUTCMonth() + 1).padStart(2, '0')}-${Date.now()}`;
+    const sql = `
+      INSERT INTO audits (code, title, description, owner, start_date, end_date, status, scope, created_at, updated_at)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8, NOW(), NOW())
+      RETURNING id, code, title, owner, start_date, end_date, status, scope
+    `;
+    const params = [
+      code,
+      plan.title,
+      plan.description ?? '',
+      plan.owner,
+      plan.startDate,
+      plan.endDate,
+      plan.status,
+      plan.scope ?? null
+    ];
+    const { rows } = await this.pool.query(sql, params);
     if (this.cache) {
-      const cached = await this.cache.get(cacheKey);
-      if (cached) {
-        return JSON.parse(cached);
+      await this.cache.del(`${this.table}:all`);
+    }
+    return rows[0];
+  }
+
+  async updatePlan(id, updates) {
+    const fields = [];
+    const values = [];
+    let index = 1;
+    const mapping = {
+      title: updates.title,
+      owner: updates.owner,
+      start_date: updates.startDate,
+      end_date: updates.endDate,
+      status: updates.status,
+      scope: updates.scope,
+      description: updates.description,
+      updated_at: new Date()
+    };
+
+    for (const [column, value] of Object.entries(mapping)) {
+      if (value === undefined) {
+        continue;
       }
+      fields.push(`${column} = $${index}`);
+      values.push(value);
+      index += 1;
     }
 
-    const { rows } = await this.pool.query('SELECT * FROM audits WHERE status = $1', ['planned']);
-    if (this.cache) {
-      await this.cache.set(cacheKey, JSON.stringify(rows), 'EX', 60);
+    if (!fields.length) {
+      const { rows } = await this.pool.query(
+        'SELECT id, code, title, owner, start_date, end_date, status, scope FROM audits WHERE id = $1',
+        [id]
+      );
+      return rows[0];
     }
-    return rows;
+
+    values.push(id);
+    const sql = `
+      UPDATE audits
+      SET ${fields.join(', ')}
+      WHERE id = $${index}
+      RETURNING id, code, title, owner, start_date, end_date, status, scope
+    `;
+    const { rows } = await this.pool.query(sql, values);
+    if (this.cache) {
+      await this.cache.del(`${this.table}:all`);
+      await this.cache.del(`${this.table}:${id}`);
+    }
+    return rows[0];
+  }
+
+  async findByTitle(title) {
+    const { rows } = await this.pool.query(
+      'SELECT id, code, title, owner, start_date, end_date, status, scope FROM audits WHERE title = $1 LIMIT 1',
+      [title]
+    );
+    return rows[0] ?? null;
   }
 }
 

--- a/backend/repositories/FollowUpRepository.js
+++ b/backend/repositories/FollowUpRepository.js
@@ -1,0 +1,25 @@
+class FollowUpRepository {
+  constructor({ pool }) {
+    this.pool = pool;
+  }
+
+  async list(filters = {}) {
+    const conditions = [];
+    const values = [];
+    if (filters.riskId) {
+      values.push(filters.riskId);
+      conditions.push(`risk_id = $${values.length}`);
+    }
+    const whereClause = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+    const sql = `
+      SELECT id, risk_id, action, owner, due_date, status
+      FROM risk_follow_ups
+      ${whereClause}
+      ORDER BY due_date ASC
+    `;
+    const { rows } = await this.pool.query(sql, values);
+    return rows;
+  }
+}
+
+module.exports = FollowUpRepository;

--- a/backend/repositories/ReportRepository.js
+++ b/backend/repositories/ReportRepository.js
@@ -4,6 +4,68 @@ class ReportRepository extends BaseRepository {
   constructor({ pool, cache }) {
     super({ pool, cache, table: 'reports' });
   }
+
+  async findAll(filters = {}) {
+    const conditions = [];
+    const values = [];
+    if (filters.status) {
+      values.push(filters.status);
+      conditions.push(`status = $${values.length}`);
+    }
+    if (filters.owner) {
+      values.push(filters.owner);
+      conditions.push(`owner ILIKE $${values.length}`);
+      values[values.length - 1] = `%${values[values.length - 1]}%`;
+    }
+    const whereClause = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+    const sql = `
+      SELECT id, title, owner, status, issued_date, content, created_at, updated_at
+      FROM reports
+      ${whereClause}
+      ORDER BY created_at DESC
+    `;
+    const { rows } = await this.pool.query(sql, values);
+    return rows;
+  }
+
+  async findById(id) {
+    const { rows } = await this.pool.query(
+      'SELECT id, title, owner, status, issued_date, content, created_at, updated_at FROM reports WHERE id = $1',
+      [id]
+    );
+    return rows[0] ?? null;
+  }
+
+  async markAsGenerated(id, content) {
+    const sql = `
+      UPDATE reports
+      SET status = 'issued', issued_date = COALESCE(issued_date, CURRENT_DATE), content = $1, updated_at = NOW()
+      WHERE id = $2
+      RETURNING id, title, owner, status, issued_date, content, created_at, updated_at
+    `;
+    const payload = typeof content === 'string' ? content : JSON.stringify(content);
+    const { rows } = await this.pool.query(sql, [payload, id]);
+    if (this.cache) {
+      await this.cache.del(`${this.table}:all`);
+      await this.cache.del(`${this.table}:${id}`);
+    }
+    return rows[0];
+  }
+
+  async createTemplate(report) {
+    const sql = `
+      INSERT INTO reports (title, owner, status, issued_date, content, created_at, updated_at)
+      VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
+      RETURNING id, title, owner, status, issued_date, content, created_at, updated_at
+    `;
+    const payload = typeof report.content === 'string' ? report.content : JSON.stringify(report.content ?? {});
+    const params = [report.title, report.owner, report.status ?? 'draft', report.issuedDate ?? null, payload];
+    const { rows } = await this.pool.query(sql, params);
+    if (this.cache) {
+      await this.cache.del(`${this.table}:all`);
+    }
+    return rows[0];
+  }
 }
 
 module.exports = ReportRepository;

--- a/backend/repositories/RiskRepository.js
+++ b/backend/repositories/RiskRepository.js
@@ -1,24 +1,141 @@
 const BaseRepository = require('./BaseRepository');
 
+const toScale = (score) => String(Math.max(1, Math.min(5, Math.round(score / 5))));
+
+const severityFromScore = (score) => {
+  if (score >= 20) {
+    return 'critical';
+  }
+  if (score >= 16) {
+    return 'high';
+  }
+  if (score >= 9) {
+    return 'medium';
+  }
+  return 'low';
+};
+
 class RiskRepository extends BaseRepository {
   constructor({ pool, cache }) {
     super({ pool, cache, table: 'risks' });
   }
 
-  async findByCategory(category) {
-    const cacheKey = `risks:category:${category}`;
+  async findAll(filters = {}) {
+    const conditions = [];
+    const values = [];
+    if (filters.status) {
+      values.push(filters.status);
+      conditions.push(`status = $${values.length}`);
+    }
+    if (filters.owner) {
+      values.push(filters.owner);
+      conditions.push(`owner ILIKE $${values.length}`);
+      values[values.length - 1] = `%${values[values.length - 1]}%`;
+    }
+    const whereClause = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+    const sql = `
+      SELECT id, code, title, category, owner, status, inherent_score, residual_score, risk_appetite,
+             reported_on, created_at
+      FROM risks
+      ${whereClause}
+      ORDER BY created_at DESC
+    `;
+    const { rows } = await this.pool.query(sql, values);
+    return rows;
+  }
+
+  async createRisk(risk) {
+    const now = new Date();
+    const code = risk.code || `RISK-${now.getUTCFullYear()}${String(now.getUTCMonth() + 1).padStart(2, '0')}-${Date.now()}`;
+    const sql = `
+      INSERT INTO risks (
+        code, title, description, category, severity_level, likelihood, impact, status, owner,
+        reported_on, mitigation_plan, inherent_score, residual_score, risk_appetite, created_at, updated_at
+      ) VALUES (
+        $1, $2, $3, $4, $5, $6, $7, $8, $9,
+        $10, $11, $12, $13, $14, NOW(), NOW()
+      )
+      RETURNING id, code, title, category, owner, status, inherent_score, residual_score, risk_appetite, reported_on, created_at
+    `;
+
+    const residual = risk.residualRisk ?? risk.inherentRisk;
+    const params = [
+      code,
+      risk.title,
+      risk.description ?? '',
+      risk.category,
+      severityFromScore(residual),
+      toScale(risk.inherentRisk),
+      toScale(residual),
+      risk.status,
+      risk.owner,
+      risk.reportedOn ? new Date(risk.reportedOn) : now,
+      '',
+      risk.inherentRisk,
+      residual,
+      risk.appetite ?? null
+    ];
+
+    const { rows } = await this.pool.query(sql, params);
     if (this.cache) {
-      const cached = await this.cache.get(cacheKey);
-      if (cached) {
-        return JSON.parse(cached);
-      }
+      await this.cache.del(`${this.table}:all`);
+    }
+    return rows[0];
+  }
+
+  async updateRisk(id, updates) {
+    const { rows: existingRows } = await this.pool.query(
+      'SELECT * FROM risks WHERE id = $1',
+      [id]
+    );
+    const current = existingRows[0];
+    if (!current) {
+      throw new Error('Risk not found');
     }
 
-    const { rows } = await this.pool.query('SELECT * FROM risks WHERE category = $1', [category]);
-    if (this.cache) {
-      await this.cache.set(cacheKey, JSON.stringify(rows), 'EX', 60);
+    const inherent = updates.inherentRisk ?? Number(current.inherent_score ?? 0);
+    const residual = updates.residualRisk ?? Number(current.residual_score ?? inherent);
+
+    const payload = {
+      title: updates.title ?? current.title,
+      description: updates.description ?? current.description,
+      category: updates.category ?? current.category,
+      owner: updates.owner ?? current.owner,
+      status: updates.status ?? current.status,
+      reported_on: updates.reportedOn ? new Date(updates.reportedOn) : current.reported_on,
+      mitigation_plan: updates.mitigationPlan ?? current.mitigation_plan ?? '',
+      inherent_score: inherent,
+      residual_score: residual,
+      risk_appetite: updates.appetite ?? current.risk_appetite,
+      likelihood: toScale(inherent),
+      impact: toScale(residual),
+      severity_level: severityFromScore(residual),
+      updated_at: new Date()
+    };
+
+    const assignments = [];
+    const values = [];
+    let index = 1;
+    for (const [column, value] of Object.entries(payload)) {
+      assignments.push(`${column} = $${index}`);
+      values.push(value);
+      index += 1;
     }
-    return rows;
+    values.push(id);
+
+    const sql = `
+      UPDATE risks
+      SET ${assignments.join(', ')}
+      WHERE id = $${index}
+      RETURNING id, code, title, category, owner, status, inherent_score, residual_score, risk_appetite, reported_on, created_at
+    `;
+
+    const { rows } = await this.pool.query(sql, values);
+    if (this.cache) {
+      await this.cache.del(`${this.table}:all`);
+      await this.cache.del(`${this.table}:${id}`);
+    }
+    return rows[0];
   }
 }
 

--- a/backend/repositories/TimesheetRepository.js
+++ b/backend/repositories/TimesheetRepository.js
@@ -1,0 +1,45 @@
+class TimesheetRepository {
+  constructor({ pool }) {
+    this.pool = pool;
+  }
+
+  async list(filters = {}) {
+    const conditions = [];
+    const values = [];
+    if (filters.auditor) {
+      values.push(filters.auditor);
+      conditions.push(`auditor_name = $${values.length}`);
+    }
+    const whereClause = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+    const sql = `
+      SELECT id, auditor_name, entry_date, hours_worked, engagement
+      FROM timesheets
+      ${whereClause}
+      ORDER BY entry_date DESC
+    `;
+    const { rows } = await this.pool.query(sql, values);
+    return rows;
+  }
+
+  async create(entry) {
+    const sql = `
+      INSERT INTO timesheets (user_id, project_code, entry_date, hours_worked, description, billable, auditor_name, engagement)
+      VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
+      RETURNING id, auditor_name, entry_date, hours_worked, engagement
+    `;
+    const params = [
+      '00000000-0000-0000-0000-000000000000',
+      entry.engagement,
+      entry.date,
+      entry.hours,
+      entry.description ?? '',
+      false,
+      entry.auditor,
+      entry.engagement
+    ];
+    const { rows } = await this.pool.query(sql, params);
+    return rows[0];
+  }
+}
+
+module.exports = TimesheetRepository;

--- a/backend/repositories/WorkingPaperRepository.js
+++ b/backend/repositories/WorkingPaperRepository.js
@@ -1,0 +1,36 @@
+class WorkingPaperRepository {
+  constructor({ pool }) {
+    this.pool = pool;
+  }
+
+  async list(filters = {}) {
+    const conditions = [];
+    const values = [];
+    if (filters.auditId) {
+      values.push(filters.auditId);
+      conditions.push(`audit_id = $${values.length}`);
+    }
+    const whereClause = conditions.length ? `WHERE ${conditions.join(' AND ')}` : '';
+    const sql = `
+      SELECT id, audit_id, name, owner, status, updated_at
+      FROM working_papers
+      ${whereClause}
+      ORDER BY updated_at DESC
+    `;
+    const { rows } = await this.pool.query(sql, values);
+    return rows;
+  }
+
+  async updateStatus(id, status) {
+    const sql = `
+      UPDATE working_papers
+      SET status = $1, updated_at = NOW()
+      WHERE id = $2
+      RETURNING id, audit_id, name, owner, status, updated_at
+    `;
+    const { rows } = await this.pool.query(sql, [status, id]);
+    return rows[0];
+  }
+}
+
+module.exports = WorkingPaperRepository;

--- a/backend/server.js
+++ b/backend/server.js
@@ -1,7 +1,7 @@
 const { createApp } = require('./app');
 
 const app = createApp();
-const port = process.env.PORT || 3000;
+const port = process.env.PORT || 4000;
 
 app.listen(port, () => {
   console.log(`OpenIA backend listening on port ${port}`);

--- a/backend/services/AuditEngine.js
+++ b/backend/services/AuditEngine.js
@@ -1,27 +1,117 @@
-const { createAuditEngagement, AuditEngagementSchema } = require('../domain/auditEngagement');
+const { AuditEngagementUpdateSchema, createAuditEngagement } = require('../domain/auditEngagement');
+const { createTimesheet, TimesheetFilterSchema } = require('../domain/timesheet');
+const {
+  WorkingPaperFilterSchema,
+  WorkingPaperUpdateSchema
+} = require('../domain/workingPaper');
 const eventBus = require('../mq/eventBus');
 
+const toAuditModel = (record) => ({
+  id: record.id.toString(),
+  title: record.title,
+  owner: record.owner,
+  startDate:
+    record.start_date instanceof Date ? record.start_date.toISOString().slice(0, 10) : record.startDate,
+  endDate: record.end_date instanceof Date ? record.end_date.toISOString().slice(0, 10) : record.endDate,
+  status: record.status,
+  scope: record.scope ?? undefined
+});
+
+const toTimesheetModel = (record) => ({
+  id: record.id.toString(),
+  auditor: record.auditor_name ?? record.auditor,
+  date: record.entry_date instanceof Date ? record.entry_date.toISOString().slice(0, 10) : record.date,
+  hours: Number(record.hours_worked ?? record.hours),
+  engagement: record.engagement ?? record.project_code
+});
+
+const toWorkingPaperModel = (record) => ({
+  id: record.id.toString(),
+  auditId: record.audit_id ? record.audit_id.toString() : record.auditId,
+  name: record.name,
+  owner: record.owner,
+  status: record.status,
+  updatedAt: record.updated_at instanceof Date ? record.updated_at.toISOString() : record.updatedAt
+});
+
 class AuditEngine {
-  constructor({ auditRepository }) {
+  constructor({ auditRepository, timesheetRepository, workingPaperRepository }) {
     this.auditRepository = auditRepository;
+    this.timesheetRepository = timesheetRepository;
+    this.workingPaperRepository = workingPaperRepository;
+
+    eventBus.subscribe('risk_updated', async (risk) => {
+      if (!risk) return;
+      const residual = Number(risk.residualRisk ?? risk.residual_score ?? 0);
+      if (residual < 16) {
+        return;
+      }
+      const title = `Focused review: ${risk.title}`;
+      const existing = await this.auditRepository.findByTitle(title);
+      if (!existing) {
+        const now = new Date();
+        const startDate = now.toISOString().slice(0, 10);
+        const endDate = new Date(now.getTime() + 14 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+        const created = await this.auditRepository.createPlan({
+          title,
+          owner: risk.owner || 'Risk Office',
+          startDate,
+          endDate,
+          status: 'planned',
+          scope: `Auto-generated engagement responding to elevated risk ${risk.title}.`
+        });
+        eventBus.publish('audit_planned', toAuditModel(created));
+      }
+    });
   }
 
-  async listAudits() {
-    return this.auditRepository.findAll();
+  async listAudits(filters = {}) {
+    const results = await this.auditRepository.findAll(filters);
+    return results.map(toAuditModel);
   }
 
   async planAudit(input) {
-    const engagement = createAuditEngagement({ ...input, status: 'planned' });
-    const stored = await this.auditRepository.create(engagement);
-    eventBus.publish('audit_planned', stored);
-    return stored;
+    const plan = createAuditEngagement(input);
+    const stored = await this.auditRepository.createPlan(plan);
+    const model = toAuditModel(stored);
+    eventBus.publish('audit_planned', model);
+    return model;
   }
 
   async updateAudit(id, input) {
-    const engagement = AuditEngagementSchema.partial().parse(input);
-    const updated = await this.auditRepository.update(id, engagement);
-    eventBus.publish('audit_updated', updated);
-    return updated;
+    const payload = AuditEngagementUpdateSchema.parse(input);
+    const stored = await this.auditRepository.updatePlan(id, payload);
+    const model = toAuditModel(stored);
+    eventBus.publish('audit_updated', model);
+    return model;
+  }
+
+  async listTimesheets(filters = {}) {
+    const parsed = TimesheetFilterSchema.parse(filters);
+    const entries = await this.timesheetRepository.list(parsed);
+    return entries.map(toTimesheetModel);
+  }
+
+  async recordTimesheet(input) {
+    const entry = createTimesheet(input);
+    const stored = await this.timesheetRepository.create(entry);
+    const model = toTimesheetModel(stored);
+    eventBus.publish('timesheet_recorded', model);
+    return model;
+  }
+
+  async listWorkingPapers(filters = {}) {
+    const parsed = WorkingPaperFilterSchema.parse(filters);
+    const papers = await this.workingPaperRepository.list(parsed);
+    return papers.map(toWorkingPaperModel);
+  }
+
+  async updateWorkingPaper(id, input) {
+    const payload = WorkingPaperUpdateSchema.parse(input);
+    const stored = await this.workingPaperRepository.updateStatus(id, payload.status);
+    const model = toWorkingPaperModel(stored);
+    eventBus.publish('working_paper_updated', model);
+    return model;
   }
 }
 

--- a/backend/services/AuthService.js
+++ b/backend/services/AuthService.js
@@ -1,31 +1,92 @@
+const crypto = require('crypto');
 const Joi = require('joi');
 
 const loginSchema = Joi.object({
-  username: Joi.string().required(),
+  email: Joi.string().email().required(),
   password: Joi.string().required()
 });
 
 class AuthService {
   constructor() {
     this.tokens = new Map();
+    this.users = [
+      {
+        id: '0001',
+        name: 'Admin User',
+        email: 'admin@example.com',
+        role: 'admin',
+        password: 'password123'
+      },
+      {
+        id: '0002',
+        name: 'Lead Auditor',
+        email: 'auditor@example.com',
+        role: 'auditor',
+        password: 'password123'
+      },
+      {
+        id: '0003',
+        name: 'Risk Manager',
+        email: 'manager@example.com',
+        role: 'manager',
+        password: 'password123'
+      }
+    ];
+  }
+
+  #formatUser(user) {
+    return { id: user.id, name: user.name, email: user.email, role: user.role };
+  }
+
+  #findUserByEmail(email) {
+    return this.users.find((user) => user.email.toLowerCase() === email.toLowerCase()) || null;
   }
 
   async login(credentials) {
-    const { username } = await loginSchema.validateAsync(credentials);
-    const token = `token-${Buffer.from(username).toString('base64')}`;
-    this.tokens.set(token, { username, issuedAt: Date.now() });
-    return { token };
+    const { email, password } = await loginSchema.validateAsync(credentials);
+    const user = this.#findUserByEmail(email);
+    if (!user || user.password !== password) {
+      const error = new Error('Invalid email or password');
+      error.status = 401;
+      throw error;
+    }
+
+    const token = `token-${crypto.randomUUID()}`;
+    this.tokens.set(token, user.id);
+    return { token, user: this.#formatUser(user) };
   }
 
   async refresh(token) {
     if (!this.tokens.has(token)) {
-      throw new Error('Invalid token');
+      const error = new Error('Invalid token');
+      error.status = 401;
+      throw error;
     }
-    const payload = this.tokens.get(token);
-    const newToken = `token-${Date.now()}`;
+    const userId = this.tokens.get(token);
+    const user = this.users.find((item) => item.id === userId);
+    if (!user) {
+      this.tokens.delete(token);
+      const error = new Error('Invalid token');
+      error.status = 401;
+      throw error;
+    }
+
+    const newToken = `token-${Date.now()}-${crypto.randomUUID()}`;
     this.tokens.delete(token);
-    this.tokens.set(newToken, { ...payload, refreshedAt: Date.now() });
-    return { token: newToken };
+    this.tokens.set(newToken, userId);
+    return { token: newToken, user: this.#formatUser(user) };
+  }
+
+  async getCurrentUser(token) {
+    if (!token) {
+      return null;
+    }
+    const stored = this.tokens.get(token);
+    if (!stored) {
+      return null;
+    }
+    const user = this.users.find((item) => item.id === stored);
+    return user ? this.#formatUser(user) : null;
   }
 }
 

--- a/backend/services/ReportService.js
+++ b/backend/services/ReportService.js
@@ -1,16 +1,47 @@
+const { ReportFiltersSchema } = require('../domain/report');
+
 class ReportService {
   constructor({ reportRepository, coreIntegration }) {
     this.reportRepository = reportRepository;
     this.coreIntegration = coreIntegration;
   }
 
-  async listReports() {
-    return this.reportRepository.findAll();
+  async listReports(filters = {}) {
+    const parsed = ReportFiltersSchema.parse(filters);
+    const results = await this.reportRepository.findAll(parsed);
+    return results.map((report) => ({
+      id: report.id.toString(),
+      title: report.title,
+      owner: report.owner,
+      status: report.status,
+      issuedDate: report.issued_date ? report.issued_date.toISOString().slice(0, 10) : ''
+    }));
   }
 
-  async generateAndStoreReport() {
-    const summary = await this.coreIntegration.generateRiskReport();
-    return this.coreIntegration.persistReport(summary);
+  async getReport(id) {
+    const report = await this.reportRepository.findById(id);
+    if (!report) {
+      return null;
+    }
+    return {
+      id: report.id.toString(),
+      title: report.title,
+      owner: report.owner,
+      status: report.status,
+      issuedDate: report.issued_date ? report.issued_date.toISOString().slice(0, 10) : ''
+    };
+  }
+
+  async generateReport(id) {
+    const payload = await this.coreIntegration.generateRiskReport();
+    const updated = await this.reportRepository.markAsGenerated(id, payload);
+    return {
+      id: updated.id.toString(),
+      title: updated.title,
+      owner: updated.owner,
+      status: updated.status,
+      issuedDate: updated.issued_date ? updated.issued_date.toISOString().slice(0, 10) : ''
+    };
   }
 }
 

--- a/backend/services/RiskEngine.js
+++ b/backend/services/RiskEngine.js
@@ -1,27 +1,131 @@
-const { createRisk, RiskSchema } = require('../domain/risk');
+const { createRisk, createRiskFromQuestionnaire, RiskFiltersSchema, updateRisk } = require('../domain/risk');
+const { FollowUpFilterSchema } = require('../domain/followUp');
 const eventBus = require('../mq/eventBus');
 
+const HIGH_THRESHOLD = 16;
+const MEDIUM_THRESHOLD = 9;
+
+const toMonthKey = (value) => {
+  const date = value ? new Date(value) : new Date();
+  const year = date.getUTCFullYear();
+  const month = String(date.getUTCMonth() + 1).padStart(2, '0');
+  return `${year}-${month}`;
+};
+
+const classifyScore = (score) => {
+  if (score >= HIGH_THRESHOLD) {
+    return 'highRisks';
+  }
+  if (score >= MEDIUM_THRESHOLD) {
+    return 'mediumRisks';
+  }
+  return 'lowRisks';
+};
+
+const toRiskModel = (record) => ({
+  id: record.id ? record.id.toString() : record.code,
+  title: record.title,
+  category: record.category,
+  inherentRisk: Number(record.inherent_score ?? record.inherentRisk ?? 0),
+  residualRisk: Number(record.residual_score ?? record.residualRisk ?? 0),
+  owner: record.owner,
+  status: record.status
+});
+
+const toFollowUpModel = (record) => ({
+  id: record.id.toString(),
+  riskId: record.risk_id ? record.risk_id.toString() : record.riskId,
+  action: record.action,
+  owner: record.owner,
+  dueDate: record.due_date instanceof Date ? record.due_date.toISOString().slice(0, 10) : record.due_date,
+  status: record.status
+});
+
 class RiskEngine {
-  constructor({ riskRepository }) {
+  constructor({ riskRepository, followUpRepository }) {
     this.riskRepository = riskRepository;
+    this.followUpRepository = followUpRepository;
   }
 
-  async listRisks() {
-    return this.riskRepository.findAll();
+  async listRisks(filters = {}) {
+    const parsedFilters = RiskFiltersSchema.parse(filters);
+    const results = await this.riskRepository.findAll(parsedFilters);
+    return results.map(toRiskModel);
   }
 
   async createRisk(input) {
     const risk = createRisk(input);
-    const stored = await this.riskRepository.create(risk);
-    eventBus.publish('risk_created', stored);
-    return stored;
+    const stored = await this.riskRepository.createRisk(risk);
+    const model = toRiskModel(stored);
+    eventBus.publish('risk_created', model);
+    return model;
   }
 
   async updateRisk(id, input) {
-    const risk = RiskSchema.partial().parse(input);
-    const updated = await this.riskRepository.update(id, risk);
-    eventBus.publish('risk_updated', updated);
-    return updated;
+    const payload = updateRisk(input);
+    const updated = await this.riskRepository.updateRisk(id, payload);
+    const model = toRiskModel(updated);
+    eventBus.publish('risk_updated', model);
+    return model;
+  }
+
+  async submitQuestionnaire(id, payload) {
+    const riskPayload = createRiskFromQuestionnaire(payload);
+    if (id && id !== 'new') {
+      return this.updateRisk(id, riskPayload);
+    }
+    const created = await this.createRisk(riskPayload);
+    eventBus.publish('risk_questionnaire_submitted', { riskId: created.id });
+    return created;
+  }
+
+  async getSummary() {
+    const risks = await this.riskRepository.findAll();
+    const counters = {
+      totalRisks: risks.length,
+      highRisks: 0,
+      mediumRisks: 0,
+      lowRisks: 0
+    };
+
+    const monthBuckets = new Map();
+    for (const record of risks) {
+      const residual = Number(record.residual_score ?? record.residualRisk ?? 0);
+      const bucket = classifyScore(residual);
+      counters[bucket] += 1;
+      const monthKey = toMonthKey(record.reported_on ?? record.created_at);
+      if (!monthBuckets.has(monthKey)) {
+        monthBuckets.set(monthKey, { month: monthKey, high: 0, medium: 0, low: 0 });
+      }
+      const entry = monthBuckets.get(monthKey);
+      if (bucket === 'highRisks') {
+        entry.high += 1;
+      } else if (bucket === 'mediumRisks') {
+        entry.medium += 1;
+      } else {
+        entry.low += 1;
+      }
+    }
+
+    const trend = [];
+    const now = new Date();
+    for (let index = 5; index >= 0; index -= 1) {
+      const date = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - index, 1));
+      const monthKey = toMonthKey(date);
+      const monthData = monthBuckets.get(monthKey) ?? { month: monthKey, high: 0, medium: 0, low: 0 };
+      trend.push(monthData);
+    }
+
+    return {
+      ...counters,
+      trend
+    };
+  }
+
+  async listFollowUps(filters = {}) {
+    const parsed = FollowUpFilterSchema.parse(filters);
+    const rows = await this.followUpRepository.list(parsed);
+    return rows.map(toFollowUpModel);
   }
 }
 

--- a/backend/tests/api.test.js
+++ b/backend/tests/api.test.js
@@ -6,38 +6,77 @@ describe('API contract tests', () => {
   let container;
 
   beforeEach(() => {
+    const user = { id: '1', name: 'Admin User', email: 'admin@example.com', role: 'admin' };
     container = {
-      authService: { login: jest.fn().mockResolvedValue({ token: 'abc' }), refresh: jest.fn() },
+      authService: {
+        login: jest.fn().mockResolvedValue({ token: 'abc', user }),
+        refresh: jest.fn(),
+        getCurrentUser: jest.fn().mockResolvedValue(user)
+      },
       riskEngine: {
-        listRisks: jest.fn().mockResolvedValue([{ id: '1', title: 'Risk', description: 'Desc', category: 'IT', severity: 'high' }]),
-        createRisk: jest.fn().mockResolvedValue({ id: '2' }),
-        updateRisk: jest.fn().mockResolvedValue({ id: '2' })
+        listRisks: jest
+          .fn()
+          .mockResolvedValue([{ id: '1', title: 'Risk', category: 'IT', inherentRisk: 16, residualRisk: 12, owner: 'Owner', status: 'open' }]),
+        createRisk: jest.fn().mockResolvedValue({ id: '2', title: 'New risk' }),
+        updateRisk: jest.fn().mockResolvedValue({ id: '2', status: 'mitigated' }),
+        getSummary: jest.fn().mockResolvedValue({
+          totalRisks: 1,
+          highRisks: 1,
+          mediumRisks: 0,
+          lowRisks: 0,
+          trend: []
+        }),
+        listFollowUps: jest.fn().mockResolvedValue([]),
+        submitQuestionnaire: jest.fn().mockResolvedValue({ id: '3', title: 'Questionnaire risk' })
       },
       auditEngine: {
-        listAudits: jest.fn().mockResolvedValue([{ id: '1', name: 'Audit', scope: 'SOX', status: 'planned' }]),
+        listAudits: jest.fn().mockResolvedValue([{ id: '1', title: 'Audit', owner: 'Lead', startDate: '2024-01-01', endDate: '2024-01-31', status: 'planned' }]),
         planAudit: jest.fn().mockResolvedValue({ id: '2', status: 'planned' }),
-        updateAudit: jest.fn().mockResolvedValue({ id: '2', status: 'in_progress' })
+        updateAudit: jest.fn().mockResolvedValue({ id: '2', status: 'in-progress' }),
+        listTimesheets: jest.fn().mockResolvedValue([{ id: '1', auditor: 'Alex', date: '2024-03-01', hours: 4, engagement: 'ENG-1' }]),
+        recordTimesheet: jest.fn().mockResolvedValue({ id: '2', auditor: 'Alex', date: '2024-03-01', hours: 4, engagement: 'ENG-1' }),
+        listWorkingPapers: jest.fn().mockResolvedValue([]),
+        updateWorkingPaper: jest.fn().mockResolvedValue({ id: '5', status: 'review' })
       },
       feedbackService: {
         submitFeedback: jest.fn().mockResolvedValue({ engagementId: '1', rating: 5, comment: 'Great' })
       },
       reportService: {
-        listReports: jest.fn().mockResolvedValue([{ id: '1', content: '{}', created_at: new Date().toISOString() }]),
-        generateAndStoreReport: jest.fn().mockResolvedValue({ id: '2', content: '{}', created_at: new Date().toISOString() })
+        listReports: jest
+          .fn()
+          .mockResolvedValue([{ id: '1', title: 'Summary', owner: 'Owner', issuedDate: '2024-01-01', status: 'draft' }]),
+        getReport: jest.fn().mockResolvedValue({ id: '1', title: 'Summary', owner: 'Owner', issuedDate: '2024-01-01', status: 'draft' }),
+        generateReport: jest.fn().mockResolvedValue({ id: '1', title: 'Summary', owner: 'Owner', issuedDate: '2024-01-01', status: 'issued' })
       },
       coreIntegration: {
-        generateRiskReport: jest.fn().mockResolvedValue({ totalRisks: 1, highSeverityRisks: 1, plannedAudits: 1 })
+        generateRiskReport: jest.fn().mockResolvedValue({
+          generatedAt: new Date().toISOString(),
+          riskSummary: { totalRisks: 1, highRisks: 1, mediumRisks: 0, lowRisks: 0 },
+          auditOverview: { total: 1, byStatus: { planned: 1 } }
+        })
       }
     };
 
     app = createApp(container);
   });
 
-  test('POST /auth/login returns token', async () => {
-    const response = await request(app).post('/auth/login').send({ username: 'john', password: 'secret' });
+  test('POST /auth/login returns token and user', async () => {
+    const response = await request(app)
+      .post('/auth/login')
+      .send({ email: 'admin@example.com', password: 'password123' });
     expect(response.status).toBe(200);
     expect(response.body.token).toBe('abc');
-    expect(container.authService.login).toHaveBeenCalledWith({ username: 'john', password: 'secret' });
+    expect(response.body.user.email).toBe('admin@example.com');
+    expect(container.authService.login).toHaveBeenCalledWith({ email: 'admin@example.com', password: 'password123' });
+  });
+
+  test('GET /auth/me returns current user', async () => {
+    const response = await request(app)
+      .get('/auth/me')
+      .set('Authorization', 'Bearer abc');
+    expect(response.status).toBe(200);
+    expect(response.body.email).toBe('admin@example.com');
+    expect(container.authService.getCurrentUser).toHaveBeenCalledWith('abc');
   });
 
   test('GET /risks returns list of risks', async () => {
@@ -47,10 +86,24 @@ describe('API contract tests', () => {
     expect(response.body[0].title).toBe('Risk');
   });
 
+  test('GET /risks/summary returns aggregated metrics', async () => {
+    const response = await request(app).get('/risks/summary');
+    expect(response.status).toBe(200);
+    expect(response.body.totalRisks).toBe(1);
+  });
+
   test('POST /audits plans audit and returns 201', async () => {
-    const response = await request(app).post('/audits').send({ name: 'New Audit', scope: 'ISO' });
+    const response = await request(app)
+      .post('/audits')
+      .send({ title: 'New Audit', owner: 'Owner', startDate: '2024-05-01', endDate: '2024-05-15', status: 'planned' });
     expect(response.status).toBe(201);
     expect(container.auditEngine.planAudit).toHaveBeenCalled();
+  });
+
+  test('GET /audits/timesheets retrieves entries', async () => {
+    const response = await request(app).get('/audits/timesheets');
+    expect(response.status).toBe(200);
+    expect(container.auditEngine.listTimesheets).toHaveBeenCalled();
   });
 
   test('POST /audits/:id/feedback delegates to feedback service', async () => {
@@ -62,6 +115,12 @@ describe('API contract tests', () => {
   test('GET /reports/summary returns aggregated metrics', async () => {
     const response = await request(app).get('/reports/summary');
     expect(response.status).toBe(200);
-    expect(response.body.totalRisks).toBe(1);
+    expect(response.body.riskSummary.totalRisks).toBe(1);
+  });
+
+  test('POST /reports/:id/generate triggers report service', async () => {
+    const response = await request(app).post('/reports/1/generate');
+    expect(response.status).toBe(201);
+    expect(container.reportService.generateReport).toHaveBeenCalledWith('1');
   });
 });

--- a/backend/tests/auditEngine.test.js
+++ b/backend/tests/auditEngine.test.js
@@ -2,21 +2,67 @@ const AuditEngine = require('../services/AuditEngine');
 const eventBus = require('../mq/eventBus');
 
 describe('AuditEngine', () => {
-  let repository;
+  let auditRepository;
+  let timesheetRepository;
+  let workingPaperRepository;
   let auditEngine;
 
   beforeEach(() => {
-    repository = {
+    auditRepository = {
       findAll: jest.fn().mockResolvedValue([]),
-      create: jest.fn().mockImplementation(async (audit) => ({ id: 'A1', ...audit })),
-      update: jest.fn().mockImplementation(async (id, audit) => ({ id, ...audit }))
+      createPlan: jest.fn().mockImplementation(async (plan) => ({
+        id: 1,
+        title: plan.title,
+        owner: plan.owner,
+        start_date: new Date(plan.startDate),
+        end_date: new Date(plan.endDate),
+        status: plan.status,
+        scope: plan.scope
+      })),
+      updatePlan: jest.fn().mockImplementation(async (id, updates) => ({
+        id,
+        title: updates.title || 'Audit',
+        owner: updates.owner || 'Owner',
+        start_date: new Date(updates.startDate || '2024-01-01'),
+        end_date: new Date(updates.endDate || '2024-01-15'),
+        status: updates.status || 'planned',
+        scope: updates.scope || null
+      })),
+      findByTitle: jest.fn().mockResolvedValue(null)
     };
-    auditEngine = new AuditEngine({ auditRepository: repository });
+    timesheetRepository = {
+      list: jest.fn().mockResolvedValue([]),
+      create: jest.fn().mockImplementation(async (entry) => ({
+        id: 5,
+        auditor_name: entry.auditor,
+        entry_date: new Date(entry.date),
+        hours_worked: entry.hours,
+        engagement: entry.engagement
+      }))
+    };
+    workingPaperRepository = {
+      list: jest.fn().mockResolvedValue([]),
+      updateStatus: jest.fn().mockResolvedValue({
+        id: 7,
+        audit_id: 3,
+        name: 'Testing',
+        owner: 'Jane',
+        status: 'review',
+        updated_at: new Date('2024-01-05T00:00:00Z')
+      })
+    };
+    auditEngine = new AuditEngine({ auditRepository, timesheetRepository, workingPaperRepository });
     eventBus.emitter.removeAllListeners();
   });
 
   test('planAudit publishes audit_planned event', async () => {
-    const payload = { name: 'IT Audit', scope: 'Infrastructure' };
+    const payload = {
+      title: 'IT Audit',
+      owner: 'James',
+      startDate: '2024-02-01',
+      endDate: '2024-02-14',
+      status: 'planned'
+    };
 
     const eventPromise = new Promise((resolve) => {
       eventBus.subscribe('audit_planned', resolve);
@@ -25,7 +71,19 @@ describe('AuditEngine', () => {
     const created = await auditEngine.planAudit(payload);
     expect(created.status).toBe('planned');
     const event = await eventPromise;
-    expect(event.id).toBe('A1');
-    expect(repository.create).toHaveBeenCalled();
+    expect(event.title).toBe('IT Audit');
+  });
+
+  test('recordTimesheet persists entry and emits event', async () => {
+    const payload = { auditor: 'Alex', date: '2024-03-01', hours: 4, engagement: 'ENG-1' };
+    const eventPromise = new Promise((resolve) => {
+      eventBus.subscribe('timesheet_recorded', resolve);
+    });
+
+    const created = await auditEngine.recordTimesheet(payload);
+    expect(timesheetRepository.create).toHaveBeenCalledWith(payload);
+    expect(created.auditor).toBe('Alex');
+    const event = await eventPromise;
+    expect(event.engagement).toBe('ENG-1');
   });
 });

--- a/backend/tests/riskEngine.test.js
+++ b/backend/tests/riskEngine.test.js
@@ -2,26 +2,45 @@ const RiskEngine = require('../services/RiskEngine');
 const eventBus = require('../mq/eventBus');
 
 describe('RiskEngine', () => {
-  let repository;
+  let riskRepository;
+  let followUpRepository;
   let riskEngine;
 
   beforeEach(() => {
-    repository = {
-      findAll: jest.fn(),
-      create: jest.fn().mockImplementation(async (risk) => ({ id: '123', ...risk })),
-      update: jest.fn().mockImplementation(async (id, risk) => ({ id, ...risk }))
+    riskRepository = {
+      findAll: jest.fn().mockResolvedValue([]),
+      createRisk: jest.fn().mockImplementation(async (risk) => ({
+        id: 123,
+        title: risk.title,
+        category: risk.category,
+        owner: risk.owner,
+        status: risk.status,
+        inherent_score: risk.inherentRisk,
+        residual_score: risk.residualRisk
+      })),
+      updateRisk: jest.fn().mockImplementation(async (id, risk) => ({
+        id,
+        title: risk.title || 'Existing',
+        category: risk.category || 'Technology',
+        owner: risk.owner || 'Owner',
+        status: risk.status || 'open',
+        inherent_score: risk.inherentRisk ?? 12,
+        residual_score: risk.residualRisk ?? 10
+      }))
     };
-    riskEngine = new RiskEngine({ riskRepository: repository });
+    followUpRepository = { list: jest.fn().mockResolvedValue([]) };
+    riskEngine = new RiskEngine({ riskRepository, followUpRepository });
     eventBus.emitter.removeAllListeners();
   });
 
   test('createRisk persists risk and emits risk_created', async () => {
     const payload = {
       title: 'Data breach',
-      description: 'Potential data leak',
-      category: 'Cyber',
-      severity: 'high',
-      controls: []
+      category: 'Technology',
+      owner: 'Alice',
+      inherentRisk: 20,
+      residualRisk: 15,
+      status: 'open'
     };
 
     const eventPromise = new Promise((resolve) => {
@@ -30,9 +49,12 @@ describe('RiskEngine', () => {
 
     const created = await riskEngine.createRisk(payload);
     expect(created.id).toBe('123');
+    expect(riskRepository.createRisk).toHaveBeenCalledWith({
+      ...payload,
+      residualRisk: 15
+    });
     const event = await eventPromise;
-    expect(event.id).toBe('123');
-    expect(repository.create).toHaveBeenCalled();
+    expect(event.title).toBe('Data breach');
   });
 
   test('updateRisk emits risk_updated message', async () => {
@@ -40,9 +62,52 @@ describe('RiskEngine', () => {
       eventBus.subscribe('risk_updated', resolve);
     });
 
-    await riskEngine.updateRisk('123', { severity: 'medium' });
+    await riskEngine.updateRisk('123', { residualRisk: 8, status: 'mitigated' });
+    expect(riskRepository.updateRisk).toHaveBeenCalledWith('123', { residualRisk: 8, status: 'mitigated' });
     const event = await eventPromise;
-    expect(event.id).toBe('123');
-    expect(repository.update).toHaveBeenCalledWith('123', { severity: 'medium' });
+    expect(event.status).toBe('mitigated');
+  });
+
+  test('getSummary aggregates metrics from repository data', async () => {
+    const now = new Date('2024-05-15T00:00:00Z');
+    riskRepository.findAll.mockResolvedValue([
+      {
+        id: 1,
+        title: 'High exposure',
+        category: 'Technology',
+        owner: 'Alice',
+        status: 'open',
+        inherent_score: 20,
+        residual_score: 18,
+        reported_on: now
+      },
+      {
+        id: 2,
+        title: 'Medium exposure',
+        category: 'Finance',
+        owner: 'Bob',
+        status: 'open',
+        inherent_score: 12,
+        residual_score: 10,
+        reported_on: new Date('2024-04-01T00:00:00Z')
+      },
+      {
+        id: 3,
+        title: 'Low exposure',
+        category: 'Operations',
+        owner: 'Carol',
+        status: 'mitigated',
+        inherent_score: 6,
+        residual_score: 4,
+        reported_on: new Date('2024-03-01T00:00:00Z')
+      }
+    ]);
+
+    const summary = await riskEngine.getSummary();
+    expect(summary.totalRisks).toBe(3);
+    expect(summary.highRisks).toBe(1);
+    expect(summary.mediumRisks).toBe(1);
+    expect(summary.lowRisks).toBe(1);
+    expect(summary.trend).toHaveLength(6);
   });
 });

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -27,6 +27,7 @@
     "@types/react-dom": "^18.2.18",
     "@vitejs/plugin-react": "^4.2.1",
     "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.4.3",

--- a/infrastructure/migrations/002_phase1_extensions.sql
+++ b/infrastructure/migrations/002_phase1_extensions.sql
@@ -1,0 +1,53 @@
+-- Migration: Phase 1 extensions for risk and audit modules
+-- Description: Adds supporting tables for follow-ups, working papers, reports and enriches existing structures.
+
+BEGIN;
+
+ALTER TABLE risks
+    ADD COLUMN IF NOT EXISTS inherent_score NUMERIC(5,2) DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS residual_score NUMERIC(5,2) DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS risk_appetite NUMERIC(5,2);
+
+ALTER TABLE audits
+    ADD COLUMN IF NOT EXISTS owner VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS start_date DATE,
+    ADD COLUMN IF NOT EXISTS end_date DATE,
+    ADD COLUMN IF NOT EXISTS scope TEXT;
+
+ALTER TABLE timesheets
+    ADD COLUMN IF NOT EXISTS auditor_name VARCHAR(255),
+    ADD COLUMN IF NOT EXISTS engagement VARCHAR(255);
+
+CREATE TABLE IF NOT EXISTS risk_follow_ups (
+    id            BIGSERIAL PRIMARY KEY,
+    risk_id       BIGINT NOT NULL REFERENCES risks(id) ON DELETE CASCADE,
+    action        TEXT NOT NULL,
+    owner         VARCHAR(255) NOT NULL,
+    due_date      DATE NOT NULL,
+    status        VARCHAR(50) NOT NULL DEFAULT 'pending' CHECK (status IN ('pending', 'in-progress', 'complete')),
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS working_papers (
+    id          BIGSERIAL PRIMARY KEY,
+    audit_id    BIGINT NOT NULL REFERENCES audits(id) ON DELETE CASCADE,
+    name        VARCHAR(255) NOT NULL,
+    owner       VARCHAR(255) NOT NULL,
+    status      VARCHAR(50) NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'review', 'approved')),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE TABLE IF NOT EXISTS reports (
+    id          BIGSERIAL PRIMARY KEY,
+    title       VARCHAR(255) NOT NULL,
+    owner       VARCHAR(255) NOT NULL,
+    status      VARCHAR(50) NOT NULL DEFAULT 'draft' CHECK (status IN ('draft', 'issued')),
+    issued_date DATE,
+    content     JSONB DEFAULT '{}'::JSONB,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+COMMIT;


### PR DESCRIPTION
## Summary
- expand the risk and audit APIs to expose summary metrics, questionnaire intake, timesheets, working-paper management, and new reporting flows that align with the frontend hooks
- introduce dedicated domain models, repositories, and migrations for follow-ups, timesheets, working papers, and reports to support Phase 1 data requirements
- enhance authentication responses with user payloads, refresh/me endpoints, and update the OpenAPI contract, tests, and configuration to cover the new capabilities

## Testing
- `npm test` *(fails: jest binary missing because dependencies cannot be installed in this environment)*
- `npm test -- --runInBand` *(fails: jest-environment-jsdom package cannot be resolved without installing additional dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68cf8e993abc832882952060b56a5e48